### PR TITLE
Types for aggregate expressions

### DIFF
--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -175,7 +175,7 @@ class TypedDataset[T](val dataset: Dataset[T])(implicit val encoder: TypedEncode
     def applyProduct[K <: HList, Out0 <: HList, Out](groupedBy: K)(
       implicit
       ct: ColumnTypes.Aux[T, K, Out0],
-      toTraversable: ToTraversable.Aux[K, List, UntypedColumn[T]]
+      toTraversable: ToTraversable.Aux[K, List, UntypedExpression[T]]
     ): GroupedByManyOps[T, K, Out0] = new GroupedByManyOps[T, K, Out0](self, groupedBy)
   }
 
@@ -244,7 +244,7 @@ class TypedDataset[T](val dataset: Dataset[T])(implicit val encoder: TypedEncode
     def applyProduct[U <: HList, Out0 <: HList, Out](columns: U)(
       implicit
       ct: ColumnTypes.Aux[T, U, Out0],
-      toTraversable: ToTraversable.Aux[U, List, UntypedColumn[T]],
+      toTraversable: ToTraversable.Aux[U, List, UntypedExpression[T]],
       tupler: Tupler.Aux[Out0, Out],
       encoder: TypedEncoder[Out]
     ): TypedDataset[Out] = {

--- a/dataset/src/main/scala/frameless/functions/Summable.scala
+++ b/dataset/src/main/scala/frameless/functions/Summable.scala
@@ -11,10 +11,17 @@ package functions
   * - Int        -> Long
   * - ...
   */
-trait Summable[T]
+trait Summable[A] {
+  def zero: A
+}
 
 object Summable {
-  implicit val summableLong: Summable[Long] = new Summable[Long] {}
-  implicit val summableBigDecimal: Summable[BigDecimal] = new Summable[BigDecimal] {}
-  implicit val summableDouble: Summable[Double] = new Summable[Double] {}
+  def apply[A](zero: A): Summable[A] = {
+    val _zero = zero
+    new Summable[A] { val zero: A = _zero }
+  }
+
+  implicit val summableLong: Summable[Long] = Summable(zero = 0L)
+  implicit val summableBigDecimal: Summable[BigDecimal] = Summable(zero = BigDecimal(0))
+  implicit val summableDouble: Summable[Double] = Summable(zero = 0.0)
 }

--- a/dataset/src/main/scala/frameless/ops/AggregateTypes.scala
+++ b/dataset/src/main/scala/frameless/ops/AggregateTypes.scala
@@ -1,0 +1,19 @@
+package frameless
+package ops
+
+import shapeless._
+
+trait AggregateTypes[V, U <: HList] {
+  type Out <: HList
+}
+
+object AggregateTypes {
+  type Aux[V, U <: HList, Out0 <: HList] = AggregateTypes[V, U] {type Out = Out0}
+
+  implicit def deriveHNil[T]: AggregateTypes.Aux[T, HNil, HNil] = new AggregateTypes[T, HNil] { type Out = HNil }
+
+  implicit def deriveCons[V, H, TT <: HList, T <: HList](
+    implicit tail: AggregateTypes.Aux[V, TT, T]
+  ): AggregateTypes.Aux[V, TypedAggregate[V, H] :: TT, H :: T] =
+    new AggregateTypes[V, TypedAggregate[V, H] :: TT] {type Out = H :: T}
+}

--- a/dataset/src/main/scala/frameless/ops/GroupByOps.scala
+++ b/dataset/src/main/scala/frameless/ops/GroupByOps.scala
@@ -12,19 +12,19 @@ class GroupedByManyOps[T, TK <: HList, K <: HList](
 )(
   implicit
   ct: ColumnTypes.Aux[T, TK, K],
-  toTraversable: ToTraversable.Aux[TK, List, UntypedColumn[T]]
+  toTraversable: ToTraversable.Aux[TK, List, UntypedExpression[T]]
 ) {
 
   def agg[TC <: HList, C <: HList, Out0 <: HList, Out1](columns: TC)(
     implicit
-    tcColumnType: ColumnTypes.Aux[T, TC, C],
+    tc: AggregateTypes.Aux[T, TC, C],
     encoder: TypedEncoder[Out1],
     append: Prepend.Aux[K, C, Out0],
     toTuple: Tupler.Aux[Out0, Out1],
-    columnsToList: ToTraversable.Aux[TC, List, UntypedColumn[T]]
+    columnsToList: ToTraversable.Aux[TC, List, UntypedExpression[T]]
   ): TypedDataset[Out1] = {
 
-    def expr(c: UntypedColumn[T]): Column = new Column(c.expr)
+    def expr(c: UntypedExpression[T]): Column = new Column(c.expr)
 
     val groupByExprs = toTraversable(groupedBy).map(expr)
     val aggregates =
@@ -50,15 +50,15 @@ class GroupedBy1Ops[K1, V](
 ) {
   private def underlying = new GroupedByManyOps(self, g1 :: HNil)
 
-  def agg[U1](c1: TypedColumn[V, U1])(
+  def agg[U1](c1: TypedAggregate[V, U1])(
     implicit encoder: TypedEncoder[(K1, U1)]
   ): TypedDataset[(K1, U1)] = underlying.agg(c1 :: HNil)
 
-  def agg[U1, U2](c1: TypedColumn[V, U1], c2: TypedColumn[V, U2])(
+  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2])(
     implicit encoder: TypedEncoder[(K1, U1, U2)]
   ): TypedDataset[(K1, U1, U2)] = underlying.agg(c1 :: c2 :: HNil)
 
-  def agg[U1, U2, U3](c1: TypedColumn[V, U1], c2: TypedColumn[V, U2], c3: TypedColumn[V, U3])(
+  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3])(
     implicit encoder: TypedEncoder[(K1, U1, U2, U3)]
   ): TypedDataset[(K1, U1, U2, U3)] = underlying.agg(c1 :: c2 :: c3 :: HNil)
 }
@@ -70,15 +70,15 @@ class GroupedBy2Ops[K1, K2, V](
 ) {
   private def underlying = new GroupedByManyOps(self, g1 :: g2 :: HNil)
 
-  def agg[U1](c1: TypedColumn[V, U1])(
+  def agg[U1](c1: TypedAggregate[V, U1])(
     implicit encoder: TypedEncoder[(K1, K2, U1)]
   ): TypedDataset[(K1, K2, U1)] = underlying.agg(c1 :: HNil)
 
-  def agg[U1, U2](c1: TypedColumn[V, U1], c2: TypedColumn[V, U2])(
+  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2])(
     implicit encoder: TypedEncoder[(K1, K2, U1, U2)]
   ): TypedDataset[(K1, K2, U1, U2)] = underlying.agg(c1 :: c2 :: HNil)
 
-  def agg[U1, U2, U3](c1: TypedColumn[V, U1], c2: TypedColumn[V, U2], c3: TypedColumn[V, U3])(
+  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3])(
     implicit encoder: TypedEncoder[(K1, K2, U1, U2, U3)]
   ): TypedDataset[(K1, K2, U1, U2, U3)] = underlying.agg(c1 :: c2 :: c3 :: HNil)
 }

--- a/dataset/src/main/scala/org/apache/spark/sql/FramelessInternals.scala
+++ b/dataset/src/main/scala/org/apache/spark/sql/FramelessInternals.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.types.ObjectType
@@ -16,6 +16,8 @@ object FramelessInternals {
         s"""Cannot resolve column name "$colNames" among (${ds.schema.fieldNames.mkString(", ")})""")
     }
   }
+
+  def expr(column: Column): Expression = column.expr
 
   def logicalPlan(ds: Dataset[_]): LogicalPlan = ds.logicalPlan
 

--- a/dataset/src/test/scala/frameless/GroupByTests.scala
+++ b/dataset/src/test/scala/frameless/GroupByTests.scala
@@ -9,17 +9,15 @@ class GroupByTests extends TypedDatasetSuite {
   // Datasets are coalesced due to https://issues.apache.org/jira/browse/SPARK-12675
 
   test("groupBy('a).agg(sum('b))") {
-    def prop[A: TypedEncoder : Ordering, B: TypedEncoder : Summable](data: List[X2[A, B]])(
-      implicit
-      ex2: TypedEncoder[X2[A, B]],
-      et2: TypedEncoder[(A, B)],
-      numeric: Numeric[B]
-    ): Prop = {
+    def prop[
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Summable : Numeric
+    ](data: List[X2[A, B]]): Prop = {
       val dataset = TypedDataset.create(data).coalesce(2)
       val A = dataset.col[A]('a)
       val B = dataset.col[B]('b)
 
-      val datasetSumByA = dataset.groupBy(A).agg(sum(B, numeric.fromInt(0))).collect().run().toVector.sortBy(_._1)
+      val datasetSumByA = dataset.groupBy(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
       val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
 
       datasetSumByA ?= sumByA
@@ -29,14 +27,11 @@ class GroupByTests extends TypedDatasetSuite {
   }
 
   test("groupBy('a).agg(sum('b), sum('c))") {
-    def prop[A: TypedEncoder : Ordering, B: TypedEncoder : Summable, C: TypedEncoder : Summable]
-      (data: List[X3[A, B, C]])
-      (implicit
-        ex3: TypedEncoder[X3[A, B, C]],
-        et3: TypedEncoder[(A, B, C)],
-        numericB: Numeric[B],
-        NumericC: Numeric[C]
-      ): Prop = {
+    def prop[
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Summable : Numeric,
+      C: TypedEncoder : Summable : Numeric
+    ](data: List[X3[A, B, C]]): Prop = {
       val dataset = TypedDataset.create(data).coalesce(2)
       val A = dataset.col[A]('a)
       val B = dataset.col[B]('b)
@@ -44,8 +39,8 @@ class GroupByTests extends TypedDatasetSuite {
 
       val datasetSumByAB = dataset
         .groupBy(A)
-        .agg(sum(B, numericB.fromInt(0)), sum(C, NumericC.fromInt(0)))
-        .collect().run().toVector.sortBy(_._1)
+        .agg(sum(B), sum(C))
+        .collect().run.toVector.sortBy(_._1)
 
       val sumByAB = data.groupBy(_.a).mapValues { xs =>
         (xs.map(_.b).sum, xs.map(_.c).sum)
@@ -60,15 +55,14 @@ class GroupByTests extends TypedDatasetSuite {
   }
 
   test("groupBy('a, 'b).agg(sum('c), sum('d))") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder : Summable, D: TypedEncoder : Summable]
-      (data: List[X4[A, B, C, D]])
-      (implicit
-        ex3: TypedEncoder[X4[A, B, C, D]],
-        et4: TypedEncoder[(A, B, C, D)],
-        numericC: Numeric[C],
-        numericD: Numeric[D],
-        o: Ordering[(A, B)] // To compare ordered vectors
-      ): Prop = {
+    def prop[
+      A: TypedEncoder,
+      B: TypedEncoder,
+      C: TypedEncoder : Summable : Numeric,
+      D: TypedEncoder : Summable : Numeric
+    ](data: List[X4[A, B, C, D]])(
+      implicit o: Ordering[(A, B)] // to compare ordered vectors
+    ): Prop = {
       val dataset = TypedDataset.create(data).coalesce(2)
       val A = dataset.col[A]('a)
       val B = dataset.col[B]('b)
@@ -77,8 +71,8 @@ class GroupByTests extends TypedDatasetSuite {
 
       val datasetSumByAB = dataset
         .groupBy(A, B)
-        .agg(sum(C, numericC.fromInt(0)), sum(D, numericD.fromInt(0)))
-        .collect().run().toVector.sortBy(x => (x._1, x._2))
+        .agg(sum(C), sum(D))
+        .collect().run.toVector.sortBy(x => (x._1, x._2))
 
       val sumByAB = data.groupBy(x => (x.a, x.b)).mapValues { xs =>
         (xs.map(_.c).sum, xs.map(_.d).sum)

--- a/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
@@ -25,14 +25,11 @@ class AggregateFunctionsTests extends TypedDatasetSuite {
       val dataset = TypedDataset.create(xs.map(X1(_)))
       val A = dataset.col[A]('a)
 
-      val datasetSum = dataset.select(sum(A)).collect().run().toVector
+      val datasetSum = dataset.select(sum(A)).collect().run().toList
 
-      xs match {
-        case Nil => datasetSum ?= Vector(None)
-        case _ :: _ => datasetSum match {
-          case Vector(Some(x)) => approximatelyEqual(x, xs.sum)
-          case other => falsified
-        }
+      datasetSum match {
+        case x :: Nil => approximatelyEqual(x, xs.sum)
+        case other => falsified
       }
     }
 


### PR DESCRIPTION
This pull request adds better types for aggregate expressions. 

It turned out that aggregate expressions give different result types if they are used in context of `select(...)` and `groupBy(...).agg(...)`. Let's consider an example:

```scala
case class Invoice(date: LocalDate, amount: Int)

val tf: TypedDataset[Invoice]
val sum: TypedDataset[Option[Int]] = tf.select(sum(tf.col('amount)))
val sumPerDate: TypedDataset[(LocalDate, Int)] = tf.groupBy(tf.col('date)).agg(sum(tf.col('amount)))
```

Previously, type of `sumPerDate` was `TypedDataset[(LocalDate, Option[Int])]`.