### PR TITLE
Add `mapGroups` and `flatMapGroups`

### DIFF
--- a/dataset/src/main/scala/frameless/ops/AggregateTypes.scala
+++ b/dataset/src/main/scala/frameless/ops/AggregateTypes.scala
@@ -12,8 +12,13 @@ object AggregateTypes {
 
   implicit def deriveHNil[T]: AggregateTypes.Aux[T, HNil, HNil] = new AggregateTypes[T, HNil] { type Out = HNil }
 
-  implicit def deriveCons[V, H, TT <: HList, T <: HList](
+  implicit def deriveCons1[V, H, TT <: HList, T <: HList](
     implicit tail: AggregateTypes.Aux[V, TT, T]
   ): AggregateTypes.Aux[V, TypedAggregate[V, H] :: TT, H :: T] =
     new AggregateTypes[V, TypedAggregate[V, H] :: TT] {type Out = H :: T}
+
+  implicit def deriveCons2[V, H, U, TT <: HList, T <: HList](
+    implicit tail: AggregateTypes.Aux[V, TT, T]
+  ): AggregateTypes.Aux[V, TypedAggregateAndColumn[V, H, U] :: TT, H :: T] =
+    new AggregateTypes[V, TypedAggregateAndColumn[V, H, U] :: TT] {type Out = H :: T}
 }

--- a/dataset/src/main/scala/frameless/ops/GroupByOps.scala
+++ b/dataset/src/main/scala/frameless/ops/GroupByOps.scala
@@ -1,46 +1,93 @@
 package frameless
 package ops
 
-import org.apache.spark.sql.Column
-
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAlias
+import org.apache.spark.sql.catalyst.encoders.OuterScopes
+import org.apache.spark.sql.catalyst.plans.logical.{MapGroups, Project}
+import org.apache.spark.sql.{Column, FramelessInternals}
 import shapeless._
-import shapeless.ops.hlist.{Tupler, ToTraversable, Prepend}
+import shapeless.ops.hlist.{Prepend, ToTraversable, Tupler}
 
-class GroupedByManyOps[T, TK <: HList, K <: HList](
+class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
   self: TypedDataset[T],
   groupedBy: TK
 )(
   implicit
   ct: ColumnTypes.Aux[T, TK, K],
-  toTraversable: ToTraversable.Aux[TK, List, UntypedExpression[T]]
+  toTraversable: ToTraversable.Aux[TK, List, UntypedExpression[T]],
+  tupler: Tupler.Aux[K, KT]
 ) {
 
-  def agg[TC <: HList, C <: HList, Out0 <: HList, Out1](columns: TC)(
-    implicit
-    tc: AggregateTypes.Aux[T, TC, C],
-    encoder: TypedEncoder[Out1],
-    append: Prepend.Aux[K, C, Out0],
-    toTuple: Tupler.Aux[Out0, Out1],
-    columnsToList: ToTraversable.Aux[TC, List, UntypedExpression[T]]
-  ): TypedDataset[Out1] = {
+  object agg extends ProductArgs {
+    def applyProduct[TC <: HList, C <: HList, Out0 <: HList, Out1](columns: TC)(
+      implicit
+      tc: AggregateTypes.Aux[T, TC, C],
+      append: Prepend.Aux[K, C, Out0],
+      toTuple: Tupler.Aux[Out0, Out1],
+      encoder: TypedEncoder[Out1],
+      columnsToList: ToTraversable.Aux[TC, List, UntypedExpression[T]]
+    ): TypedDataset[Out1] = {
 
-    def expr(c: UntypedExpression[T]): Column = new Column(c.expr)
+      def expr(c: UntypedExpression[T]): Column = new Column(c.expr)
 
-    val groupByExprs = toTraversable(groupedBy).map(expr)
-    val aggregates =
-      if (retainGroupColumns) columnsToList(columns).map(expr)
-      else groupByExprs ++ columnsToList(columns).map(expr)
+      val groupByExprs = toTraversable(groupedBy).map(expr)
+      val aggregates =
+        if (retainGroupColumns) columnsToList(columns).map(expr)
+        else groupByExprs ++ columnsToList(columns).map(expr)
 
-    val aggregated = self.dataset.toDF()
-      .groupBy(groupByExprs: _*)
-      .agg(aggregates.head, aggregates.tail: _*)
-      .as[Out1](TypedExpressionEncoder[Out1])
+      val aggregated = self.dataset.toDF()
+        .groupBy(groupByExprs: _*)
+        .agg(aggregates.head, aggregates.tail: _*)
+        .as[Out1](TypedExpressionEncoder[Out1])
 
-    new TypedDataset[Out1](aggregated)
+      new TypedDataset[Out1](aggregated)
+    }
+  }
+
+  def mapGroups[U: TypedEncoder](f: (KT, Iterator[T]) => U)(
+    implicit kencoder: TypedEncoder[KT]
+  ): TypedDataset[U] = {
+    val func = (key: KT, it: Iterator[T]) => Iterator(f(key, it))
+    flatMapGroups(func)
+  }
+
+  def flatMapGroups[U: TypedEncoder](
+    f: (KT, Iterator[T]) => TraversableOnce[U]
+  )(implicit kencoder: TypedEncoder[KT]): TypedDataset[U] = {
+    val cols = toTraversable(groupedBy)
+    val logicalPlan = FramelessInternals.logicalPlan(self.dataset)
+    val withKeyColumns = logicalPlan.output ++ cols.map(_.expr).map(UnresolvedAlias)
+    val withKey = Project(withKeyColumns, logicalPlan)
+    val executed = FramelessInternals.executePlan(self.dataset, withKey)
+    val keyAttributes = executed.analyzed.output.takeRight(cols.size)
+    val dataAttributes = executed.analyzed.output.dropRight(cols.size)
+
+    val mapGroups = MapGroups(
+      f,
+      TypedExpressionEncoder[tupler.Out].resolve(keyAttributes, OuterScopes.outerScopes),
+      TypedExpressionEncoder[T](self.encoder).resolve(dataAttributes, OuterScopes.outerScopes),
+      keyAttributes,
+      executed.analyzed
+    )(TypedExpressionEncoder[U])
+
+    val groupedAndFlatMapped = FramelessInternals.mkDataset(
+      self.dataset.sqlContext,
+      mapGroups,
+      TypedExpressionEncoder[U]
+    )
+
+    new TypedDataset(groupedAndFlatMapped)
   }
 
   private def retainGroupColumns: Boolean = {
     self.dataset.sqlContext.getConf("spark.sql.retainGroupColumns", "true").toBoolean
+  }
+}
+
+object GroupedByManyOps {
+  /** Utility function to help Spark with serialization of closures */
+  def tuple1[K1, V, U](f: (K1, Iterator[V]) => U): (Tuple1[K1], Iterator[V]) => U = {
+    (x: Tuple1[K1], it: Iterator[V]) => f(x._1, it)
   }
 }
 
@@ -49,18 +96,40 @@ class GroupedBy1Ops[K1, V](
   g1: TypedColumn[V, K1]
 ) {
   private def underlying = new GroupedByManyOps(self, g1 :: HNil)
+  private implicit def eg1 = g1.uencoder
 
-  def agg[U1](c1: TypedAggregate[V, U1])(
-    implicit encoder: TypedEncoder[(K1, U1)]
-  ): TypedDataset[(K1, U1)] = underlying.agg(c1 :: HNil)
+  def agg[U1](c1: TypedAggregate[V, U1]): TypedDataset[(K1, U1)] = {
+    implicit val e1 = c1.aencoder
+    underlying.agg(c1)
+  }
 
-  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2])(
-    implicit encoder: TypedEncoder[(K1, U1, U2)]
-  ): TypedDataset[(K1, U1, U2)] = underlying.agg(c1 :: c2 :: HNil)
+  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2]): TypedDataset[(K1, U1, U2)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder
+    underlying.agg(c1, c2)
+  }
 
-  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3])(
-    implicit encoder: TypedEncoder[(K1, U1, U2, U3)]
-  ): TypedDataset[(K1, U1, U2, U3)] = underlying.agg(c1 :: c2 :: c3 :: HNil)
+  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3]): TypedDataset[(K1, U1, U2, U3)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder
+    underlying.agg(c1, c2, c3)
+  }
+
+  def agg[U1, U2, U3, U4](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4]): TypedDataset[(K1, U1, U2, U3, U4)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder
+    underlying.agg(c1, c2, c3, c4)
+  }
+
+  def agg[U1, U2, U3, U4, U5](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4], c5: TypedAggregate[V, U5]): TypedDataset[(K1, U1, U2, U3, U4, U5)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder; implicit val e5 = c5.aencoder
+    underlying.agg(c1, c2, c3, c4, c5)
+  }
+
+  def mapGroups[U: TypedEncoder](f: (K1, Iterator[V]) => U): TypedDataset[U] = {
+    underlying.mapGroups(GroupedByManyOps.tuple1(f))
+  }
+
+  def flatMapGroups[U: TypedEncoder](f: (K1, Iterator[V]) => TraversableOnce[U]): TypedDataset[U] = {
+    underlying.flatMapGroups(GroupedByManyOps.tuple1(f))
+  }
 }
 
 class GroupedBy2Ops[K1, K2, V](
@@ -69,16 +138,39 @@ class GroupedBy2Ops[K1, K2, V](
   g2: TypedColumn[V, K2]
 ) {
   private def underlying = new GroupedByManyOps(self, g1 :: g2 :: HNil)
+  private implicit def eg1 = g1.uencoder
+  private implicit def eg2 = g2.uencoder
 
-  def agg[U1](c1: TypedAggregate[V, U1])(
-    implicit encoder: TypedEncoder[(K1, K2, U1)]
-  ): TypedDataset[(K1, K2, U1)] = underlying.agg(c1 :: HNil)
+  def agg[U1](c1: TypedAggregate[V, U1]): TypedDataset[(K1, K2, U1)] = {
+    implicit val e1 = c1.aencoder
+    underlying.agg(c1)
+  }
 
-  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2])(
-    implicit encoder: TypedEncoder[(K1, K2, U1, U2)]
-  ): TypedDataset[(K1, K2, U1, U2)] = underlying.agg(c1 :: c2 :: HNil)
+  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2]): TypedDataset[(K1, K2, U1, U2)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder
+    underlying.agg(c1, c2)
+  }
 
-  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3])(
-    implicit encoder: TypedEncoder[(K1, K2, U1, U2, U3)]
-  ): TypedDataset[(K1, K2, U1, U2, U3)] = underlying.agg(c1 :: c2 :: c3 :: HNil)
+  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3]): TypedDataset[(K1, K2, U1, U2, U3)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder
+    underlying.agg(c1, c2, c3)
+  }
+
+  def agg[U1, U2, U3, U4](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4]): TypedDataset[(K1, K2, U1, U2, U3, U4)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder
+    underlying.agg(c1 , c2 , c3 , c4)
+  }
+
+  def agg[U1, U2, U3, U4, U5](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4], c5: TypedAggregate[V, U5]): TypedDataset[(K1, K2, U1, U2, U3, U4, U5)] = {
+    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder; implicit val e5 = c5.aencoder
+    underlying.agg(c1, c2, c3, c4, c5)
+  }
+
+  def mapGroups[U: TypedEncoder](f: ((K1, K2), Iterator[V]) => U): TypedDataset[U] = {
+    underlying.mapGroups(f)
+  }
+
+  def flatMapGroups[U: TypedEncoder](f: ((K1, K2), Iterator[V]) => TraversableOnce[U]): TypedDataset[U] = {
+    underlying.flatMapGroups(f)
+  }
 }

--- a/dataset/src/test/scala/frameless/CollectTests.scala
+++ b/dataset/src/test/scala/frameless/CollectTests.scala
@@ -14,6 +14,7 @@ class CollectTests extends TypedDatasetSuite {
     check(forAll(prop[X2[Long, Int]] _))
 
     check(forAll(prop[X2[X2[Int, String], Boolean]] _))
+    check(forAll(prop[Tuple1[Option[Int]]] _))
 
     check(forAll(prop[Int] _))
     check(forAll(prop[Long] _))

--- a/dataset/src/test/scala/frameless/GroupByTests.scala
+++ b/dataset/src/test/scala/frameless/GroupByTests.scala
@@ -7,6 +7,23 @@ import org.scalacheck.Prop._
 
 class GroupByTests extends TypedDatasetSuite {
   // Datasets are coalesced due to https://issues.apache.org/jira/browse/SPARK-12675
+  test("groupByMany('a).agg(sum('b))") {
+    def prop[
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Summable : Numeric
+    ](data: List[X2[A, B]]): Prop = {
+      val dataset = TypedDataset.create(data).coalesce(2)
+      val A = dataset.col[A]('a)
+      val B = dataset.col[B]('b)
+
+      val datasetSumByA = dataset.groupByMany(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
+      val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
+
+      datasetSumByA ?= sumByA
+    }
+
+    check(forAll(prop[Int, Long] _))
+  }
 
   test("groupBy('a).agg(sum('b))") {
     def prop[
@@ -18,6 +35,26 @@ class GroupByTests extends TypedDatasetSuite {
       val B = dataset.col[B]('b)
 
       val datasetSumByA = dataset.groupBy(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
+      val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
+
+      datasetSumByA ?= sumByA
+    }
+
+    check(forAll(prop[Int, Long] _))
+  }
+
+  test("groupBy('a).mapGroups('a, sum('b))") {
+    def prop[
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Summable : Numeric
+    ](data: List[X2[A, B]]): Prop = {
+      val dataset = TypedDataset.create(data).coalesce(2)
+      val A = dataset.col[A]('a)
+      val B = dataset.col[B]('b)
+
+      val datasetSumByA = dataset.groupBy(A)
+        .mapGroups { case (a, xs) => (a, xs.map(_.b).sum) }
+        .collect().run().toVector.sortBy(_._1)
       val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
 
       datasetSumByA ?= sumByA
@@ -56,13 +93,11 @@ class GroupByTests extends TypedDatasetSuite {
 
   test("groupBy('a, 'b).agg(sum('c), sum('d))") {
     def prop[
-      A: TypedEncoder,
-      B: TypedEncoder,
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Ordering,
       C: TypedEncoder : Summable : Numeric,
       D: TypedEncoder : Summable : Numeric
-    ](data: List[X4[A, B, C, D]])(
-      implicit o: Ordering[(A, B)] // to compare ordered vectors
-    ): Prop = {
+    ](data: List[X4[A, B, C, D]]): Prop = {
       val dataset = TypedDataset.create(data).coalesce(2)
       val A = dataset.col[A]('a)
       val B = dataset.col[B]('b)
@@ -84,5 +119,81 @@ class GroupByTests extends TypedDatasetSuite {
     }
 
     check(forAll(prop[Byte, Int, Long, BigDecimal] _))
+  }
+
+  test("groupBy('a, 'b).mapGroups('a, 'b, sum('c))") {
+    def prop[
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Ordering,
+      C: TypedEncoder : Summable : Numeric
+    ](data: List[X3[A, B, C]]): Prop = {
+      val dataset = TypedDataset.create(data).coalesce(2)
+      val A = dataset.col[A]('a)
+      val B = dataset.col[B]('b)
+      val C = dataset.col[C]('c)
+
+      val datasetSumByAB = dataset
+        .groupBy(A, B)
+        .mapGroups { case ((a, b), xs) => (a, b, xs.map(_.c).sum) }
+        .collect().run().toVector.sortBy(x => (x._1, x._2))
+
+      val sumByAB = data.groupBy(x => (x.a, x.b))
+        .mapValues { xs => xs.map(_.c).sum }
+        .toVector.map { case ((a, b), c) => (a, b, c) }.sortBy(x => (x._1, x._2))
+
+      datasetSumByAB ?= sumByAB
+    }
+
+    check(forAll(prop[Byte, Int, Long] _))
+  }
+
+  test("groupBy('a).mapGroups(('a, toVector(('a, 'b))") {
+    def prop[
+      A: TypedEncoder,
+      B: TypedEncoder
+    ](data: Vector[X2[A, B]]): Prop = {
+      val dataset = TypedDataset.create(data).coalesce(2)
+      val A = dataset.col[A]('a)
+
+      val datasetGrouped = dataset
+        .groupBy(A)
+        .mapGroups((a, xs) => (a, xs.toVector))
+        .collect().run.toMap
+
+      val dataGrouped = data.groupBy(_.a)
+
+      datasetGrouped ?= dataGrouped
+    }
+
+    check(forAll(prop[Short, Option[Short]] _))
+    check(forAll(prop[Option[Short], Short] _))
+    check(forAll(prop[X1[Option[Short]], Short] _))
+  }
+
+  test("groupBy('a).flatMapGroups(('a, toVector(('a, 'b))") {
+    def prop[
+      A: TypedEncoder : Ordering,
+      B: TypedEncoder : Ordering
+    ](data: Vector[X2[A, B]]): Prop = {
+      val dataset = TypedDataset.create(data).coalesce(2)
+      val A = dataset.col[A]('a)
+
+      val datasetGrouped = dataset
+        .groupBy(A)
+        .flatMapGroups((a, xs) => xs.map(x => (a, x)))
+        .collect().run
+        .sorted
+
+      val dataGrouped = data
+        .groupBy(_.a).toSeq
+        .flatMap { case (a, xs) => xs.map(x => (a, x)) }
+        .sorted
+
+      datasetGrouped ?= dataGrouped
+    }
+
+    check(forAll(prop[Short, Option[Short]] _))
+    check(forAll(prop[Option[Short], Short] _))
+    check(forAll(prop[X1[Option[Short]], Short] _))
   }
 }

--- a/dataset/src/test/scala/frameless/XN.scala
+++ b/dataset/src/test/scala/frameless/XN.scala
@@ -8,6 +8,8 @@ object X1 {
   implicit def arbitrary[A: Arbitrary]: Arbitrary[X1[A]] = {
     Arbitrary(implicitly[Arbitrary[A]].arbitrary.map(X1(_)))
   }
+
+  implicit def ordering[A: Ordering]: Ordering[X1[A]] = Ordering[A].on(_.a)
 }
 
 case class X2[A, B](a: A, b: B)
@@ -16,6 +18,8 @@ object X2 {
   implicit def arbitrary[A: Arbitrary, B: Arbitrary]: Arbitrary[X2[A, B]] = {
     Arbitrary(Arbitrary.arbTuple2[A, B].arbitrary.map((X2.apply[A, B] _).tupled))
   }
+
+  implicit def ordering[A: Ordering, B: Ordering]: Ordering[X2[A, B]] = Ordering.Tuple2[A, B].on(x => (x.a, x.b))
 }
 
 case class X3[A, B, C](a: A, b: B, c: C)
@@ -24,6 +28,9 @@ object X3 {
   implicit def arbitrary[A: Arbitrary, B: Arbitrary, C: Arbitrary]: Arbitrary[X3[A, B, C]] = {
     Arbitrary(Arbitrary.arbTuple3[A, B, C].arbitrary.map((X3.apply[A, B, C] _).tupled))
   }
+
+  implicit def ordering[A: Ordering, B: Ordering, C: Ordering]: Ordering[X3[A, B, C]] =
+    Ordering.Tuple3[A, B, C].on(x => (x.a, x.b, x.c))
 }
 
 case class X4[A, B, C, D](a: A, b: B, c: C, d: D)
@@ -32,5 +39,8 @@ object X4 {
   implicit def arbitrary[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary]: Arbitrary[X4[A, B, C, D]] = {
     Arbitrary(Arbitrary.arbTuple4[A, B, C, D].arbitrary.map((X4.apply[A, B, C, D] _).tupled))
   }
+
+  implicit def ordering[A: Ordering, B: Ordering, C: Ordering, D: Ordering]: Ordering[X4[A, B, C, D]] =
+    Ordering.Tuple4[A, B, C, D].on(x => (x.a, x.b, x.c, x.d))
 }
 

--- a/dataset/src/test/scala/frameless/package.scala
+++ b/dataset/src/test/scala/frameless/package.scala
@@ -16,4 +16,8 @@ package object frameless {
   implicit val arbSqlTimestamp = Arbitrary {
     Arbitrary.arbitrary[Long].map(SQLTimestamp)
   }
+
+  implicit def arbTuple1[A: Arbitrary] = Arbitrary {
+    Arbitrary.arbitrary[A].map(Tuple1(_))
+  }
 }


### PR DESCRIPTION
- extend `groupBy(...).agg` up to 5 arguments
- remove redundant implicits