### PR TITLE
Add `<`, `<=`, `>`, `>=`

### DIFF
--- a/core/src/main/scala/frameless/CatalystOrdered.scala
+++ b/core/src/main/scala/frameless/CatalystOrdered.scala
@@ -1,0 +1,17 @@
+package frameless
+
+/** Types that can be ordered/compared by Catalyst. */
+trait CatalystOrdered[A]
+
+object CatalystOrdered {
+  implicit object IntOrdered extends CatalystOrdered[Int]
+  implicit object BooleanOrdered extends CatalystOrdered[Boolean]
+  implicit object ByteOrdered extends CatalystOrdered[Byte]
+  implicit object ShortOrdered extends CatalystOrdered[Short]
+  implicit object LongOrdered extends CatalystOrdered[Long]
+  implicit object FloatOrdered extends CatalystOrdered[Float]
+  implicit object DoubleOrdered extends CatalystOrdered[Double]
+  implicit object SQLDateOrdered extends CatalystOrdered[SQLDate]
+  implicit object SQLTimestampOrdered extends CatalystOrdered[SQLTimestamp]
+  implicit object StringOrdered extends CatalystOrdered[String]
+}

--- a/dataset/src/main/scala/frameless/FramelessSyntax.scala
+++ b/dataset/src/main/scala/frameless/FramelessSyntax.scala
@@ -1,0 +1,13 @@
+package frameless
+
+import org.apache.spark.sql.{Column, Dataset}
+
+trait FramelessSyntax {
+  implicit class ColumnSyntax(self: Column) {
+    def typed[T, U: TypedEncoder]: TypedColumn[T, U] = new TypedColumn[T, U](self)
+  }
+
+  implicit class DatasetSyntax[T: TypedEncoder](self: Dataset[T]) {
+    def typed: TypedDataset[T] = TypedDataset.create[T](self)
+  }
+}

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -43,9 +43,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: U): TypedColumn[T, Boolean] = {
-    new TypedColumn[T, Boolean](untyped === other)
-  }
+  def ===(other: U): TypedColumn[T, Boolean] = (untyped === other).typed
 
   /** Equality test.
     * {{{
@@ -54,9 +52,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = {
-    new TypedColumn[T, Boolean](untyped === other.untyped)
-  }
+  def ===(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (untyped === other.untyped).typed
 
   /** Sum of this expression and another expression.
     * {{{
@@ -67,7 +63,7 @@ sealed class TypedColumn[T, U](
     * apache/spark
     */
   def plus(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    new TypedColumn[T, U](self.untyped.plus(u.untyped))
+    self.untyped.plus(u.untyped).typed
 
   /** Sum of this expression and another expression.
     * {{{
@@ -88,7 +84,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def +(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](self.untyped.plus(u))
+  def +(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = self.untyped.plus(u).typed
 
   /** Unary minus, i.e. negate the expression.
     * {{{
@@ -98,8 +94,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def unary_-(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](-self.untyped)
-
+  def unary_-(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = (-self.untyped).typed
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -110,7 +105,7 @@ sealed class TypedColumn[T, U](
     * apache/spark
     */
   def minus(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    new TypedColumn[T, U](self.untyped.minus(u.untyped))
+    self.untyped.minus(u.untyped).typed
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -131,7 +126,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def -(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](self.untyped.minus(u))
+  def -(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = self.untyped.minus(u).typed
 
   /** Multiplication of this expression and another expression.
     * {{{
@@ -142,7 +137,7 @@ sealed class TypedColumn[T, U](
     * apache/spark
     */
   def multiply(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    new TypedColumn[T, U](self.untyped.multiply(u.untyped))
+    self.untyped.multiply(u.untyped).typed
 
   /** Multiplication of this expression and another expression.
     * {{{
@@ -162,7 +157,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def *(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](self.untyped.multiply(u))
+  def *(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = self.untyped.multiply(u).typed
 
   /**
     * Division this expression by another expression.
@@ -174,7 +169,7 @@ sealed class TypedColumn[T, U](
     * @param u another column of the same type
     * apache/spark
     */
-  def divide(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = new TypedColumn[T, Double](self.untyped.divide(u.untyped))
+  def divide(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = self.untyped.divide(u.untyped).typed
 
   /**
     * Division this expression by another expression.
@@ -198,7 +193,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def /(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = new TypedColumn[T, Double](self.untyped.divide(u))
+  def /(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = self.untyped.divide(u).typed
 
   /** Casts the column to a different type.
     * {{{
@@ -206,7 +201,7 @@ sealed class TypedColumn[T, U](
     * }}}
     */
   def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TypedColumn[T, A] =
-    new TypedColumn(self.untyped.cast(TypedEncoder[A].targetDataType))
+    self.untyped.cast(TypedEncoder[A].targetDataType).typed
 }
 
 sealed trait TypedAggregate[T, A] extends UntypedExpression[T] {

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -1,5 +1,7 @@
 package frameless
 
+import frameless.syntax._
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.{Column, FramelessInternals}
 import shapeless.ops.record.Selector
@@ -257,5 +259,12 @@ object TypedColumn {
       lgen: LabelledGeneric.Aux[T, H],
       selector: Selector.Aux[H, K, V]
     ): Exists[T, K, V] = new Exists[T, K, V] {}
+  }
+
+  implicit class OrderedTypedColumnSyntax[T, U: CatalystOrdered](col: TypedColumn[T, U]) {
+    def <(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped < other.untyped).typed
+    def <=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped <= other.untyped).typed
+    def >(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped > other.untyped).typed
+    def >=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped >= other.untyped).typed
   }
 }

--- a/dataset/src/main/scala/frameless/syntax/package.scala
+++ b/dataset/src/main/scala/frameless/syntax/package.scala
@@ -1,0 +1,3 @@
+package frameless
+
+package object syntax extends FramelessSyntax

--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -1,0 +1,35 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+import scala.math.Ordering.Implicits._
+
+class ColumnTests extends TypedDatasetSuite {
+
+  test("select('a < 'b, 'a <= 'b, 'a > 'b, 'a >= 'b)") {
+    def prop[A: TypedEncoder : frameless.CatalystOrdered : scala.math.Ordering](a: A, b: A): Prop = {
+      val dataset = TypedDataset.create(X2(a, b) :: Nil)
+      val A = dataset.col('a)
+      val B = dataset.col('b)
+
+      val dataset2 = dataset.selectMany(A < B, A <= B, A > B, A >= B).collect().run().toVector
+
+      dataset2 ?= Vector((a < b, a <= b, a > b, a >= b))
+    }
+
+    implicit val sqlDateOrdering: Ordering[SQLDate] = Ordering.by(_.days)
+    implicit val sqlTimestmapOrdering: Ordering[SQLTimestamp] = Ordering.by(_.us)
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Boolean] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Float] _))
+    check(forAll(prop[Double] _))
+    check(forAll(prop[SQLDate] _))
+    check(forAll(prop[SQLTimestamp] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/FilterTests.scala
+++ b/dataset/src/test/scala/frameless/FilterTests.scala
@@ -4,7 +4,7 @@ import org.scalacheck.Prop
 import org.scalacheck.Prop._
 
 class FilterTests extends TypedDatasetSuite {
-  test("filter") {
+  test("filter('a == lit(b))") {
     def prop[A: TypedEncoder](elem: A, data: Vector[X1[A]])(implicit ex1: TypedEncoder[X1[A]]): Prop = {
       val dataset = TypedDataset.create(data)
       val A = dataset.col('a)

--- a/dataset/src/test/scala/frameless/JoinTests.scala
+++ b/dataset/src/test/scala/frameless/JoinTests.scala
@@ -4,15 +4,12 @@ import org.scalacheck.Prop
 import org.scalacheck.Prop._
 
 class JoinTests extends TypedDatasetSuite {
-  import scala.math.Ordering.Implicits._
-
   test("ab.joinLeft(ac, ab.a, ac.a)") {
-    def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
-      implicit
-      lefte: TypedEncoder[X2[A, B]],
-      righte: TypedEncoder[X2[A, C]],
-      joinede: TypedEncoder[(X2[A, B], Option[X2[A, C]])]
-    ): Prop = {
+    def prop[
+      A : TypedEncoder : Ordering,
+      B : TypedEncoder : Ordering,
+      C : TypedEncoder : Ordering
+    ](left: List[X2[A, B]], right: List[X2[A, C]]): Prop = {
       val leftDs = TypedDataset.create(left)
       val rightDs = TypedDataset.create(right)
       val joinedDs = leftDs
@@ -38,12 +35,11 @@ class JoinTests extends TypedDatasetSuite {
   }
 
   test("ab.join(ac, ab.a, ac.a)") {
-    def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
-      implicit
-      lefte: TypedEncoder[X2[A, B]],
-      righte: TypedEncoder[X2[A, C]],
-      joinede: TypedEncoder[(X2[A, B], X2[A, C])]
-    ): Prop = {
+    def prop[
+      A : TypedEncoder : Ordering,
+      B : TypedEncoder : Ordering,
+      C : TypedEncoder : Ordering
+    ](left: List[X2[A, B]], right: List[X2[A, C]]): Prop = {
       val leftDs = TypedDataset.create(left)
       val rightDs = TypedDataset.create(right)
       val joinedDs = leftDs


### PR DESCRIPTION
- Add syntax to build TypedDataset and TypedColumn from vanilla ones, fixes #42
- Add `Ordered` for types that can be ordered/compared by Spark
- Add `<`, `<=`, `>`, `>=`
