### PR TITLE
cats upgrade to 0.7.2 and more unit tests in the "cats" subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ project/plugins/project/
 bin/
 .settings/
 
+# IntelliJ specific
+.idea
+
 # OS X
 .DS_Store
 node_modules

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-val catsv = "0.4.1"
 val sparkVersion = "2.0.1"
+val catsv = "0.7.2"
 val sparkTesting = "0.3.3"
 val scalatest = "2.2.5"
 val shapeless = "2.3.0"

--- a/cats/src/main/scala/cats/bec/implicits.scala
+++ b/cats/src/main/scala/cats/bec/implicits.scala
@@ -1,9 +1,10 @@
 package frameless
 package cats
 
-import algebra.{Monoid, Order, Semigroup}
 import _root_.cats.implicits._
+import org.apache.spark.SparkContext
 
+import algebra.{Monoid, Order, Semigroup}
 import scala.reflect.ClassTag
 import org.apache.spark.rdd.RDD
 
@@ -12,6 +13,10 @@ object implicits {
     def csum(implicit m: Monoid[A]): A = lhs.reduce(_ |+| _)
     def cmin(implicit o: Order[A]): A = lhs.reduce(_ min _)
     def cmax(implicit o: Order[A]): A = lhs.reduce(_ max _)
+  }
+
+  implicit class seqToRdd[A: ClassTag](seq: Seq[A])(implicit sc: SparkContext) {
+    def toRdd: RDD[A] = sc.makeRDD(seq)
   }
 
   implicit class pairRddOps[K: ClassTag, V: ClassTag](lhs: RDD[(K, V)]) {

--- a/cats/src/main/scala/cats/bec/implicits.scala
+++ b/cats/src/main/scala/cats/bec/implicits.scala
@@ -2,9 +2,8 @@ package frameless
 package cats
 
 import _root_.cats.implicits._
-import org.apache.spark.SparkContext
+import _root_.cats._
 
-import algebra.{Monoid, Order, Semigroup}
 import scala.reflect.ClassTag
 import org.apache.spark.rdd.RDD
 
@@ -13,10 +12,6 @@ object implicits {
     def csum(implicit m: Monoid[A]): A = lhs.reduce(_ |+| _)
     def cmin(implicit o: Order[A]): A = lhs.reduce(_ min _)
     def cmax(implicit o: Order[A]): A = lhs.reduce(_ max _)
-  }
-
-  implicit class seqToRdd[A: ClassTag](seq: Seq[A])(implicit sc: SparkContext) {
-    def toRdd: RDD[A] = sc.makeRDD(seq)
   }
 
   implicit class pairRddOps[K: ClassTag, V: ClassTag](lhs: RDD[(K, V)]) {


### PR DESCRIPTION
- Example of how to use Kryo when using Monoids with intermediate collections that don't extend Serialiazable. 
- Include one simple toRdd convenient implicit method for converting Scala Sequences to RDDs. 