### PR TITLE
Upgrade to Spark 2.0.1 and fix broken tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 val catsv = "0.4.1"
-val sparkCats = "2.0.0"
-val sparkVersion = "2.0.0"
+val sparkVersion = "2.0.1"
 val sparkTesting = "0.3.3"
 val scalatest = "2.2.5"
 val shapeless = "2.3.0"
@@ -24,7 +23,7 @@ lazy val cats = project
   .settings(publishSettings: _*)
   .settings(libraryDependencies ++= Seq(
     "org.typelevel"    %% "cats"       % catsv,
-    "org.apache.spark" %% "spark-core" % sparkCats))
+    "org.apache.spark" %% "spark-core" % sparkVersion))
 
 lazy val dataset = project
   .settings(name := "frameless-dataset")

--- a/dataset/src/test/scala/frameless/JoinTests.scala
+++ b/dataset/src/test/scala/frameless/JoinTests.scala
@@ -4,8 +4,10 @@ import org.scalacheck.Prop
 import org.scalacheck.Prop._
 
 class JoinTests extends TypedDatasetSuite {
+  import scala.math.Ordering.Implicits._
+
   test("ab.joinLeft(ac, ab.a, ac.a)") {
-    def prop[A: TypedEncoder : Ordering, B, C](left: List[X2[A, B]], right: List[X2[A, C]])(
+    def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
       implicit
       lefte: TypedEncoder[X2[A, B]],
       righte: TypedEncoder[X2[A, C]],
@@ -15,7 +17,7 @@ class JoinTests extends TypedDatasetSuite {
       val rightDs = TypedDataset.create(right)
       val joinedDs = leftDs
         .joinLeft(rightDs, leftDs.col('a), rightDs.col('a))
-        .collect().run().toVector.sortBy(_._1.a)
+        .collect().run().toVector.sorted
 
       val rightKeys = right.map(_.a).toSet
       val joined = {
@@ -29,14 +31,14 @@ class JoinTests extends TypedDatasetSuite {
         } yield (ab, None)
       }.toVector
 
-      (joined.sortBy(_._1.a) ?= joinedDs) && (joinedDs.map(_._1).toSet ?= left.toSet)
+      (joined.sorted ?= joinedDs) && (joinedDs.map(_._1).toSet ?= left.toSet)
     }
 
     check(forAll(prop[Int, Long, String] _))
   }
 
   test("ab.join(ac, ab.a, ac.a)") {
-    def prop[A: TypedEncoder : Ordering, B, C](left: List[X2[A, B]], right: List[X2[A, C]])(
+    def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
       implicit
       lefte: TypedEncoder[X2[A, B]],
       righte: TypedEncoder[X2[A, C]],
@@ -46,7 +48,7 @@ class JoinTests extends TypedDatasetSuite {
       val rightDs = TypedDataset.create(right)
       val joinedDs = leftDs
         .join(rightDs, leftDs.col('a), rightDs.col('a))
-        .collect().run().toVector.sortBy(_._1.a)
+        .collect().run().toVector.sorted
 
       val joined = {
         for {
@@ -55,7 +57,7 @@ class JoinTests extends TypedDatasetSuite {
         } yield (ab, ac)
       }.toVector
 
-      joined.sortBy(_._1.a) ?= joinedDs
+      joined.sorted ?= joinedDs
     }
 
     check(forAll(prop[Int, Long, String] _))

--- a/dataset/src/test/scala/frameless/JoinTests.scala
+++ b/dataset/src/test/scala/frameless/JoinTests.scala
@@ -4,10 +4,7 @@ import org.scalacheck.Prop
 import org.scalacheck.Prop._
 
 class JoinTests extends TypedDatasetSuite {
-  // doesn't work consistenly due to https://issues.apache.org/jira/browse/SPARK-16802
-  // TODO test once 2.0.1 is released
-
-  ignore("ab.joinLeft(ac, ab.a, ac.a)") {
+  test("ab.joinLeft(ac, ab.a, ac.a)") {
     def prop[A: TypedEncoder : Ordering, B, C](left: List[X2[A, B]], right: List[X2[A, C]])(
       implicit
       lefte: TypedEncoder[X2[A, B]],
@@ -38,7 +35,7 @@ class JoinTests extends TypedDatasetSuite {
     check(forAll(prop[Int, Long, String] _))
   }
 
-  ignore("ab.join(ac, ab.a, ac.a)") {
+  test("ab.join(ac, ab.a, ac.a)") {
     def prop[A: TypedEncoder : Ordering, B, C](left: List[X2[A, B]], right: List[X2[A, C]])(
       implicit
       lefte: TypedEncoder[X2[A, B]],

--- a/dataset/src/test/scala/frameless/forward/IntersectTests.scala
+++ b/dataset/src/test/scala/frameless/forward/IntersectTests.scala
@@ -5,7 +5,7 @@ import org.scalacheck.Prop._
 import math.Ordering
 
 class IntersectTests extends TypedDatasetSuite {
-  ignore("intersect") {
+  test("intersect") {
     def prop[A: TypedEncoder : Ordering](data1: Vector[A], data2: Vector[A]): Prop = {
       val dataset1 = TypedDataset.create(data1)
       val dataset2 = TypedDataset.create(data2)

--- a/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
@@ -10,11 +10,15 @@ class AggregateFunctionsTests extends TypedDatasetSuite {
   def approximatelyEqual[A](a: A, b: A)(implicit numeric: Numeric[A]): Prop = {
     val da = numeric.toDouble(a)
     val db = numeric.toDouble(b)
+    val epsilon = 1E-6
     // Spark has a weird behaviour concerning expressions that should return Inf
     // Most of the time they return NaN instead, for instance stddev of Seq(-7.827553978923477E227, -5.009124275715786E153)
     if((da.isNaN || da.isInfinity) && (db.isNaN || db.isInfinity)) proved
-    else if ((da - db).abs < 1e-6) proved
-    else falsified :| "Expected " + a + " but got " + b
+    else if (
+      (da - db).abs < epsilon ||
+      (da - db).abs < da.abs / 100)
+        proved
+    else falsified :| s"Expected $a but got $b, which is more than 1% off and greater than epsilon = $epsilon."
   }
 
   test("sum") {


### PR DESCRIPTION
This PR upgrade Spark to 2.0.1, which means we should be able to have consistently passing tests (:champagne:!)   

The upgrade commit is straightforward, but I think the test fixing commits could benefit from a review.
@kanterov could you have a look at fc3cf09?
@bamine do you think 801b5af is enough for this stddev thing?