### PR TITLE
Add TypedEncoder for Char

### DIFF
--- a/dataset/src/test/scala/frameless/CollectTests.scala
+++ b/dataset/src/test/scala/frameless/CollectTests.scala
@@ -21,6 +21,7 @@ class CollectTests extends TypedDatasetSuite {
     check(forAll(prop[Double] _))
     check(forAll(prop[Float] _))
     check(forAll(prop[Short] _))
+    check(forAll(prop[Char] _))
     check(forAll(prop[Byte] _))
     check(forAll(prop[Boolean] _))
     check(forAll(prop[String] _))


### PR DESCRIPTION
Based on gitter discussion, it turned out to be tricky because while `Char` is a primitive type, Spark doesn't support it natively.