### PR TITLE
Adding support for arithmetic operations on typed columns 

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -79,7 +79,7 @@ sealed class TypedColumn[T, U](
 
   /** Sum of this expression (column) with a constant.
     * {{{
-    *   // Scala: The following selects the sum of a person's height and weight.
+    *   // The following selects the sum of a person's height and weight.
     *   people.select( people('height) + 2 )
     * }}}
     *
@@ -90,7 +90,7 @@ sealed class TypedColumn[T, U](
 
   /** Unary minus, i.e. negate the expression.
     * {{{
-    *   // Scala: select the amount column and negates all values.
+    *   // Select the amount column and negates all values.
     *   df.select( -df('amount) )
     * }}}
     *
@@ -122,7 +122,7 @@ sealed class TypedColumn[T, U](
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
-    *   // Scala: The following selects the difference between people's height and their weight.
+    *   // The following selects the difference between people's height and their weight.
     *   people.select( people('height) - 1 )
     * }}}
     *
@@ -165,7 +165,7 @@ sealed class TypedColumn[T, U](
   /**
     * Division this expression by another expression.
     * {{{
-    *   // Scala: The following divides a person's height by their weight.
+    *   // The following divides a person's height by their weight.
     *   people.select( people('height) / people('weight) )
     * }}}
     *
@@ -177,7 +177,7 @@ sealed class TypedColumn[T, U](
   /**
     * Division this expression by another expression.
     * {{{
-    *   // Scala: The following divides a person's height by their weight.
+    *   // The following divides a person's height by their weight.
     *   people.select( people('height) / people('weight) )
     * }}}
     *
@@ -189,7 +189,7 @@ sealed class TypedColumn[T, U](
   /**
     * Division this expression by another expression.
     * {{{
-    *   // Scala: The following divides a person's height by their weight.
+    *   // The following divides a person's height by their weight.
     *   people.select( people('height) / 2 )
     * }}}
     *

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -245,9 +245,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     TypedDataset.create[(T, Option[A])](joinedDs)
   }
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple1[A]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -255,9 +254,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     ca: TypedColumn[T, A]
   ): TypedDataset[A] = selectMany(ca).as[A]() // TODO fix selectMany for a single parameter
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple2[A,B]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -266,9 +264,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     cb: TypedColumn[T, B]
   ): TypedDataset[(A, B)] = selectMany(ca, cb)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple3[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -278,9 +275,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     cc: TypedColumn[T, C]
   ): TypedDataset[(A, B, C)] = selectMany(ca, cb, cc)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple4[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -291,9 +287,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      cd: TypedColumn[T, D]
   ): TypedDataset[(A, B, C, D)] = selectMany(ca, cb, cc, cd)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple5[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -305,9 +300,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      ce: TypedColumn[T, E]
   ): TypedDataset[(A, B, C, D, E)] = selectMany(ca, cb, cc, cd, ce)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple6[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -320,9 +314,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      cf: TypedColumn[T, F]
   ): TypedDataset[(A, B, C, D, E, F)] = selectMany(ca, cb, cc, cd, ce, cf)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple7[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -336,9 +329,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      cg: TypedColumn[T, G]
   ): TypedDataset[(A, B, C, D, E, F, G)] = selectMany(ca, cb, cc, cd, ce, cf, cg)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple8[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -353,9 +345,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      ch: TypedColumn[T, H]
   ): TypedDataset[(A, B, C, D, E, F, G, H)] = selectMany(ca, cb, cc, cd, ce, cf, cg, ch)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple9[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -371,9 +362,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      ci: TypedColumn[T, I]
   ): TypedDataset[(A, B, C, D, E, F, G, H, I)] = selectMany(ca, cb, cc, cd, ce, cf, cg, ch, ci)
 
-  /** Type-safe projection from type T to TupleN[A,B,...]
+  /** Type-safe projection from type T to Tuple10[A,B,...]
     * {{{
-    *   // Scala:
     *   d.select( d('a), d('a)+d('b), ... )
     * }}}
     */
@@ -389,8 +379,6 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
      ci: TypedColumn[T, I],
      cj: TypedColumn[T, J]
   ): TypedDataset[(A, B, C, D, E, F, G, H, I, J)] = selectMany(ca, cb, cc, cd, ce, cf, cg, ch, ci, cj)
-
- 
 
   object selectMany extends ProductArgs {
     def applyProduct[U <: HList, Out0 <: HList, Out](columns: U)(

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -245,20 +245,152 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     TypedDataset.create[(T, Option[A])](joinedDs)
   }
 
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
   def select[A: TypedEncoder](
     ca: TypedColumn[T, A]
   ): TypedDataset[A] = selectMany(ca).as[A]() // TODO fix selectMany for a single parameter
 
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
   def select[A: TypedEncoder, B: TypedEncoder](
     ca: TypedColumn[T, A],
     cb: TypedColumn[T, B]
   ): TypedDataset[(A, B)] = selectMany(ca, cb)
 
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
   def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder](
     ca: TypedColumn[T, A],
     cb: TypedColumn[T, B],
     cc: TypedColumn[T, C]
   ): TypedDataset[(A, B, C)] = selectMany(ca, cb, cc)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+  def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D]
+  ): TypedDataset[(A, B, C, D)] = selectMany(ca, cb, cc, cd)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+  def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D],
+     ce: TypedColumn[T, E]
+  ): TypedDataset[(A, B, C, D, E)] = selectMany(ca, cb, cc, cd, ce)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+  def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder, F: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D],
+     ce: TypedColumn[T, E],
+     cf: TypedColumn[T, F]
+  ): TypedDataset[(A, B, C, D, E, F)] = selectMany(ca, cb, cc, cd, ce, cf)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+ def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder, F: TypedEncoder, G: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D],
+     ce: TypedColumn[T, E],
+     cf: TypedColumn[T, F],
+     cg: TypedColumn[T, G]
+  ): TypedDataset[(A, B, C, D, E, F, G)] = selectMany(ca, cb, cc, cd, ce, cf, cg)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+ def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder, F: TypedEncoder, G: TypedEncoder, H: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D],
+     ce: TypedColumn[T, E],
+     cf: TypedColumn[T, F],
+     cg: TypedColumn[T, G],
+     ch: TypedColumn[T, H]
+  ): TypedDataset[(A, B, C, D, E, F, G, H)] = selectMany(ca, cb, cc, cd, ce, cf, cg, ch)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+ def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder, F: TypedEncoder, G: TypedEncoder, H: TypedEncoder, I: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D],
+     ce: TypedColumn[T, E],
+     cf: TypedColumn[T, F],
+     cg: TypedColumn[T, G],
+     ch: TypedColumn[T, H],
+     ci: TypedColumn[T, I]
+  ): TypedDataset[(A, B, C, D, E, F, G, H, I)] = selectMany(ca, cb, cc, cd, ce, cf, cg, ch, ci)
+
+  /** Type-safe projection from type T to TupleN[A,B,...]
+    * {{{
+    *   // Scala:
+    *   d.select( d('a), d('a)+d('b), ... )
+    * }}}
+    */
+ def select[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder, F: TypedEncoder, G: TypedEncoder, H: TypedEncoder, I: TypedEncoder, J: TypedEncoder](
+     ca: TypedColumn[T, A],
+     cb: TypedColumn[T, B],
+     cc: TypedColumn[T, C],
+     cd: TypedColumn[T, D],
+     ce: TypedColumn[T, E],
+     cf: TypedColumn[T, F],
+     cg: TypedColumn[T, G],
+     ch: TypedColumn[T, H],
+     ci: TypedColumn[T, I],
+     cj: TypedColumn[T, J]
+  ): TypedDataset[(A, B, C, D, E, F, G, H, I, J)] = selectMany(ca, cb, cc, cd, ce, cf, cg, ch, ci, cj)
+
+ 
 
   object selectMany extends ProductArgs {
     def applyProduct[U <: HList, Out0 <: HList, Out](columns: U)(

--- a/dataset/src/main/scala/org/apache/spark/sql/FramelessInternals.scala
+++ b/dataset/src/main/scala/org/apache/spark/sql/FramelessInternals.scala
@@ -19,6 +19,8 @@ object FramelessInternals {
 
   def expr(column: Column): Expression = column.expr
 
+  def column(column: Column): Expression = column.expr
+
   def logicalPlan(ds: Dataset[_]): LogicalPlan = ds.logicalPlan
 
   def executePlan(ds: Dataset[_], plan: LogicalPlan): QueryExecution = {

--- a/dataset/src/test/scala/frameless/FilterTests.scala
+++ b/dataset/src/test/scala/frameless/FilterTests.scala
@@ -16,5 +16,22 @@ class FilterTests extends TypedDatasetSuite {
     }
 
     check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+
+  test("filter with  arithmetic expressions: addition") {
+    check(forAll { (data: Vector[X1[Int]]) =>
+      val ds = TypedDataset.create(data)
+      val res = ds.filter((ds('a) + 1) === (ds('a) + 1)).collect().run().toVector
+      res ?= data
+    })
+  }
+
+  test("filter with arithmetic expressions: multiplication") {
+    val t = X1(1) :: X1(2) :: X1(3) :: Nil
+    val tds: TypedDataset[X1[Int]] = TypedDataset.create(t)
+
+    assert(tds.filter(tds('a) * 2 === 2).collect().run().toVector === Vector(X1(1)))
+    assert(tds.filter(tds('a) * 3 === 3).collect().run().toVector === Vector(X1(1)))
   }
 }

--- a/dataset/src/test/scala/frameless/SelectTests.scala
+++ b/dataset/src/test/scala/frameless/SelectTests.scala
@@ -78,6 +78,195 @@ class SelectTests extends TypedDatasetSuite {
     check(forAll(prop[String, String, Int, Int] _))
   }
 
+  test("select('a,'b,'c,'d) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
+  test("select('a,'b,'c,'d,'a) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4, a1).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
+  test("select('a,'b,'c,'d,'a, 'c) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
+  test("select('a,'b,'c,'d,'a,'c,'b) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
+  test("select('a,'b,'c,'d,'a,'c,'b, 'a) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2, a1).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b, a) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
+  test("select('a,'b,'c,'d,'a,'c,'b,'a,'c) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2, a1, a3).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b, a, c) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
+  test("select('a,'b,'c,'d,'a,'c,'b,'a,'c, 'd) FROM abcd") {
+    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
+      implicit
+      ea: TypedEncoder[A],
+      eb: TypedEncoder[B],
+      ec: TypedEncoder[C],
+      ed: TypedEncoder[D],
+      ex4: TypedEncoder[X4[A, B, C, D]],
+      ca: ClassTag[A]
+    ): Prop = {
+      val dataset = TypedDataset.create(data)
+      val a1 = dataset.col[A]('a)
+      val a2 = dataset.col[B]('b)
+      val a3 = dataset.col[C]('c)
+      val a4 = dataset.col[D]('d)
+
+      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2, a1, a3, a4).collect().run().toVector
+      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b, a, c, d) }
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int, Int, Int, Int] _))
+    check(forAll(prop[String, Int, Int, Int] _))
+    check(forAll(prop[String, Boolean, Int, Float] _))
+  }
+
   test("select('a.b)") {
     def prop[A, B, C](data: Vector[X2[X2[A, B], C]])(
       implicit
@@ -107,8 +296,8 @@ class SelectTests extends TypedDatasetSuite {
     ): Prop = {
       val ds = TypedDataset.create(data)
 
-      val dataset2 = ds.select( ds('a) + const ).collect().run().toVector
-      val data2 = data.map { case X1(a) => num.plus(a,const) }
+      val dataset2 = ds.select(ds('a) + const).collect().run().toVector
+      val data2 = data.map { case X1(a) => num.plus(a, const) }
 
       dataset2 ?= data2
     }
@@ -129,8 +318,8 @@ class SelectTests extends TypedDatasetSuite {
     ): Prop = {
       val ds = TypedDataset.create(data)
 
-      val dataset2 = ds.select( ds('a) * const ).collect().run().toVector
-      val data2 = data.map { case X1(a) => num.times(a,const) }
+      val dataset2 = ds.select(ds('a) * const).collect().run().toVector
+      val data2 = data.map { case X1(a) => num.times(a, const) }
 
       dataset2 ?= data2
     }
@@ -151,8 +340,8 @@ class SelectTests extends TypedDatasetSuite {
     ): Prop = {
       val ds = TypedDataset.create(data)
 
-      val dataset2 = ds.select( ds('a) - const ).collect().run().toVector
-      val data2 = data.map { case X1(a) => num.minus(a,const) }
+      val dataset2 = ds.select(ds('a) - const).collect().run().toVector
+      val data2 = data.map { case X1(a) => num.minus(a, const) }
 
       dataset2 ?= data2
     }
@@ -172,7 +361,7 @@ class SelectTests extends TypedDatasetSuite {
     ): Prop = {
       val ds = TypedDataset.create(data)
 
-      if(const != 0) {
+      if (const != 0) {
         val dataset2 = ds.select(ds('a) / const).collect().run().toVector.asInstanceOf[Vector[A]]
         val data2 = data.map { case X1(a) => frac.div(a, const) }
         dataset2 ?= data2
@@ -184,8 +373,8 @@ class SelectTests extends TypedDatasetSuite {
 
   test("tests to cover problematic dataframe column names during projections") {
     case class Foo(i: Int)
-    val e = TypedDataset.create[Foo]( Foo(1) :: Nil )
-    val t: TypedDataset[(Int, Int)] = e.select( e.col('i) * 2, e.col('i) )
+    val e = TypedDataset.create[Foo](Foo(1) :: Nil)
+    val t: TypedDataset[(Int, Int)] = e.select(e.col('i) * 2, e.col('i))
     assert(t.select(t.col('_1)).collect().run().toList === List(2))
     // Issue #54
     val fooT = t.select(t.col('_1)).map(x => Tuple1.apply(x)).as[Foo]

--- a/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
@@ -43,9 +43,9 @@ class AggregateFunctionsTests extends TypedDatasetSuite {
     check(forAll(prop[Double] _))
 
     // doesn't work yet because resulting type is different
-    // check(forAll(prop[Int] _)
-    // check(forAll(prop[Short] _)
-    // check(forAll(prop[Byte] _)
+    // check(forAll(prop[Int] _))
+    // check(forAll(prop[Short]_))
+    // check(forAll(prop[Byte]_))
   }
 
   test("avg") {


### PR DESCRIPTION
Here is an example of what this tries to achieve. 

```
val e = TypedDataset.create[(Int, String, Long)]( (1,"a",2L) :: (2, "b", 4L) :: (2, "b", 1L) :: Nil )
e.select(e('_1) + 1).collect().run()
res1: Seq[Int] = WrappedArray(2, 3, 3)
```
Maybe there are other PR that try to achieve the same? Please advice! I will try to refine this based on comments. Thanks!

Given that I did the mistake of originating my previous PR from master, this PR also includes the changes from #47. Moving forward each PR will be from a separate branch that always branches of the current remote master of frameless. I will fix this as soon as we are done merging #47. 