### PR TITLE
Fix column names

### DIFF
--- a/dataset/src/main/scala/frameless/ops/GroupByOps.scala
+++ b/dataset/src/main/scala/frameless/ops/GroupByOps.scala
@@ -39,7 +39,7 @@ class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
         .agg(aggregates.head, aggregates.tail: _*)
         .as[Out1](TypedExpressionEncoder[Out1])
 
-      new TypedDataset[Out1](aggregated)
+      TypedDataset.create[Out1](aggregated)
     }
   }
 
@@ -76,7 +76,7 @@ class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
       TypedExpressionEncoder[U]
     )
 
-    new TypedDataset(groupedAndFlatMapped)
+    TypedDataset.create(groupedAndFlatMapped)
   }
 
   private def retainGroupColumns: Boolean = {

--- a/dataset/src/test/scala/frameless/SchemaTests.scala
+++ b/dataset/src/test/scala/frameless/SchemaTests.scala
@@ -1,0 +1,37 @@
+package frameless
+
+import frameless.functions.aggregate._
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+import org.scalatest.Matchers
+
+class SchemaTests extends TypedDatasetSuite with Matchers {
+
+  def prop[A](dataset: TypedDataset[A]): Prop = {
+    TypedExpressionEncoder.targetStructType(dataset.encoder) ?= dataset.dataset.schema
+  }
+
+  test("schema of groupBy('a).agg(sum('b))") {
+    val df0 = TypedDataset.create(X2(1L, 1L) :: Nil)
+    val _a = df0.col('a)
+    val _b = df0.col('b)
+
+    val df = df0.groupBy(_a).agg(sum(_b))
+
+    check(prop(df))
+  }
+
+  test("schema of select(lit(1L))") {
+    val df0 = TypedDataset.create("test" :: Nil)
+    val df = df0.select(lit(1L))
+
+    check(prop(df))
+  }
+
+  test("schema of select(lit(1L), lit(2L)).as[X2[Long, Long]]") {
+    val df0 = TypedDataset.create("test" :: Nil)
+    val df = df0.select(lit(1L), lit(2L)).as[X2[Long, Long]]
+
+    check(prop(df))
+  }
+}


### PR DESCRIPTION
Column names as seen by frameless, and as done as Spark were different.
This caused varienty issues with safe column referencing. Now we keep
this invariant by renaming columns if we find difference in derived vs.
actual schema.