### PR TITLE
Comparing standard Datsets with TypedDatasets

### DIFF
--- a/docs/src/main/tut/GettingStarted.md
+++ b/docs/src/main/tut/GettingStarted.md
@@ -56,7 +56,7 @@ val cities: TypedDataset[String] = apartmentsTypedDS.select(apartmentsTypedDS('c
 
 This is completely safe, for instance suppose we misspell `city`:
 ```tut:book:fail
-apartmentsTypedDS.select(apartmentsTypedDS('citi))                                          ^
+apartmentsTypedDS.select(apartmentsTypedDS('citi))
 ```
 This gets caught at compile-time.
 With `Dataset` the error appears at run-time.
@@ -94,11 +94,11 @@ priceBySurfaceUnit.collect.run()
 Looks like it worked, but that `cast` looks unsafe right? Actually it is safe.
 Let's try to cast a `TypedColumn` of `String` to `Double`: 
 ```tut:book:fail
-apartmentsTypedDS('city).cast[Double]                            ^
+apartmentsTypedDS('city).cast[Double]
 ``` 
 The compile-time error tells us that to perform the cast, an evidence (in the form of `CatalystCast[String, Double]`) must be available.
 
-Check [here](https://github.com/adelbertc/frameless/blob/566bde7/core/src/main/scala/frameless/CatalystCast.scala) for the set of available `CatalystCast`.
+Check [here](https://github.com/adelbertc/frameless/blob/master/core/src/main/scala/frameless/CatalystCast.scala) for the set of available `CatalystCast`.
  
 ## TypeSafe TypedDataset casting and projections 
 
@@ -114,7 +114,7 @@ as the types in `U` and `T` align.
 The cast is valid and the expression compiles: 
  
 ```tut:book
-case class UpdatedSurface(citi: String, surface: Int)
+case class UpdatedSurface(city: String, surface: Int)
 val updated = apartmentsTypedDS.select(apartmentsTypedDS('city), apartmentsTypedDS('surface) + 2).as[UpdatedSurface]
 updated.show(2).run()
 ```

--- a/docs/src/main/tut/GettingStarted.md
+++ b/docs/src/main/tut/GettingStarted.md
@@ -1,7 +1,7 @@
 # Getting started
 This tutorial introduces `TypedDataset`s through a small toy example.
 The following imports are needed to make all code examples compile.
-```tut:book
+```tut:silent
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SparkSession
 import frameless.functions.aggregate._
@@ -14,79 +14,227 @@ spark.sparkContext.setLogLevel("WARN")
 
 import spark.implicits._
 ``` 
+
 ## Creating TypedDataset instances
+
 We start by defining a simple case class that will be the basis of our examples.
-```tut:book
-case class Appartment(city: String, surface: Int, price: Double)
+```tut:silent
+case class Apartment(city: String, surface: Int, price: Double)
 ``` 
-And let's define a few `Appartment` instances:
-```tut:book
-val appartments = Seq(
-    Appartment("Paris", 50, 300000.0),
-    Appartment("Paris", 100, 450000.0),
-    Appartment("Paris", 25, 250000.0),
-    Appartment("Lyon", 83, 200000.0),
-    Appartment("Lyon", 45, 133000.0),
-    Appartment("Nice", 74, 325000.0)
+And let's define a few `Apartment` instances:
+```tut:silent
+val apartments = Seq(
+    Apartment("Paris", 50, 300000.0),
+    Apartment("Paris", 100, 450000.0),
+    Apartment("Paris", 25, 250000.0),
+    Apartment("Lyon", 83, 200000.0),
+    Apartment("Lyon", 45, 133000.0),
+    Apartment("Nice", 74, 325000.0)
     )
 ```
-We are now ready to instantiate a `TypedDataset[Appartment]`:
+We are now ready to instantiate a `TypedDataset[Apartment]`:
 ```tut:book
-val appartmentsTypedDS = TypedDataset.create(appartments)
+val apartmentsTypedDS = TypedDataset.create(apartments)
 ```
 We can also create it from an existing `Dataset`:
 ```tut:book
-val appartmentsDS = spark.createDataset(appartments)
-val appartmentsTypedDS = TypedDataset.create(appartmentsDS)
+val apartmentsDS = spark.createDataset(apartments)
+val apartmentsTypedDS = TypedDataset.create(apartmentsDS)
 ```
+Or use the frameless syntax:
+```tut:book
+import frameless.syntax._
+
+val apartmentsTypedDS2 = spark.createDataset(apartments).typed
+```
+
 ## Typesafe column referencing
 This is how we select a particular column from a `TypedDataset`: 
 ```tut:book
-val cities: TypedDataset[String] = appartmentsTypedDS.select(appartmentsTypedDS('city))
+val cities: TypedDataset[String] = apartmentsTypedDS.select(apartmentsTypedDS('city))
 ```
-This is completely safe, for instance suppose we made a typo:
+
+This is completely safe, for instance suppose we misspell `city`:
 ```tut:book:fail
-appartmentsTypedDS.select(appartmentsTypedDS('citi))                                          ^
+apartmentsTypedDS.select(apartmentsTypedDS('citi))                                          ^
 ```
 This gets caught at compile-time.
 With `Dataset` the error appears at run-time.
 ```tut:book:fail
-appartmentsDS.select('citi)
+apartmentsDS.select('citi)
 ``` 
-Let us now try to get the price by surface unit: 
+
+`select()` supports arbitrary column operations: 
+```tut:book
+apartmentsTypedDS.select(apartmentsTypedDS('surface) * 10, apartmentsTypedDS('surface) + 2).show().run()
+```
+
+*Note: that unlike the standard Spark api here `show()` is lazy. It requires to apply `run()` for the
+ `show` job to materialize.*  
+
+
+Let us now try to compute the price by surface unit: 
 ```tut:book:fail
-val priceBySurfaceUnit = appartmentsTypedDS.select(appartmentsTypedDS('price)/appartmentsTypedDS('surface))                                                                          ^
+val priceBySurfaceUnit = apartmentsTypedDS.select(apartmentsTypedDS('price)/apartmentsTypedDS('surface))                                                                          ^
 ```
 Argh! Looks like we can't divide a `TypedColumn` of `Double` by `Int`. 
-Well, we can cast our `Int`s to `Double`s explicitely to proceed with the computation.
+Well, we can cast our `Int`s to `Double`s explicitly to proceed with the computation.
 ```tut:book
-val priceBySurfaceUnit = appartmentsTypedDS.select(appartmentsTypedDS('price)/appartmentsTypedDS('surface).cast[Double])
-priceBySurfaceUnit.collect.run()
+val priceBySurfaceUnit = apartmentsTypedDS.select(apartmentsTypedDS('price)/apartmentsTypedDS('surface).cast[Double])
+priceBySurfaceUnit.collect().run()
 ``` 
-Or perform the cast implicitely :
+
+Alternatively, we can perform the cast implicitly:
 ```tut:book
 import frameless.implicits.widen._
 
-val priceBySurfaceUnit = appartmentsTypedDS.select(appartmentsTypedDS('price)/appartmentsTypedDS('surface))
+val priceBySurfaceUnit = apartmentsTypedDS.select(apartmentsTypedDS('price)/apartmentsTypedDS('surface))
 priceBySurfaceUnit.collect.run()
 ``` 
 Looks like it worked, but that `cast` looks unsafe right? Actually it is safe.
 Let's try to cast a `TypedColumn` of `String` to `Double`: 
 ```tut:book:fail
-appartmentsTypedDS('city).cast[Double]                            ^
+apartmentsTypedDS('city).cast[Double]                            ^
 ``` 
 The compile-time error tells us that to perform the cast, an evidence (in the form of `CatalystCast[String, Double]`) must be available.
-To check the list of available `CatalystCast` instances https://github.com/adelbertc/frameless/blob/566bde7/core/src/main/scala/frameless/CatalystCast.scala. 
-## GroupBy and Aggregations
-Let's suppose we wanted to retrieve the average appartment price in each city
+
+Check [here](https://github.com/adelbertc/frameless/blob/566bde7/core/src/main/scala/frameless/CatalystCast.scala) for the set of available `CatalystCast`.
+ 
+## TypeSafe TypedDataset casting and projections 
+
+With `select()` the resulting TypedDataset is of type `TypedDataset[TupleN[...]]` (with N in `[1...10]`). 
+For example, if we select three columns with types `String`, `Int`, and `Boolean` the result will have type 
+`TypedDataset[(String,Int,Boolean)]`.
+We often want to give more expressive types to the result of our computations.  
+ 
+
+`as[T]` allows us to safely cast a `TypedDataset[U]` to another of type `TypedDataset[T]` as long 
+as the types in `U` and `T` align.
+ 
+The cast is valid and the expression compiles: 
+ 
 ```tut:book
-val priceByCity = appartmentsTypedDS.groupBy(appartmentsTypedDS('city)).agg(avg(appartmentsTypedDS('price)))
+case class UpdatedSurface(citi: String, surface: Int)
+val updated = apartmentsTypedDS.select(apartmentsTypedDS('city), apartmentsTypedDS('surface) + 2).as[UpdatedSurface]
+updated.show(2).run()
+```
+
+Next we try to cast a `(String, String)` to an `UpdatedSurface` (which has types `String`, `Int`). 
+The cast is not valid and the expression does not compile:
+
+```tut:book:fail
+apartmentsTypedDS.select(apartmentsTypedDS('city), apartmentsTypedDS('city)).as[UpdatedSurface]
+``` 
+
+### Projections 
+
+We often want to work with a subset of the fields in a dataset. 
+Projections allows to easily select the fields we are interested 
+while preserving their initial name and types for extra safety. 
+
+Here is an example using the `TypedDataset[Apartment]` with an additional column:
+
+```tut:book
+import frameless.implicits.widen._
+
+val aptds = apartmentsTypedDS // For shorter expressions
+
+case class ApartmentDetails(city: String, price: Double, surface: Int, ratio: Double)
+val aptWithRatio = aptds.select(aptds('city), aptds('price), aptds('surface), aptds('price)/aptds('surface)).as[ApartmentDetails]
+```
+
+Suppose we only want to work with `city` and `ratio`:
+
+```tut:book
+case class CityInfo(city: String, ratio: Double)
+
+val cityRatio = aptWithRatio.project[CityInfo]
+
+cityRatio.show(2).run()
+```
+
+Suppose we only want to work with `price` and `ratio`:
+
+```tut:book
+case class PriceInfo(ratio: Double, price: Double)
+
+val priceInfo = aptWithRatio.project[PriceInfo]
+
+priceInfo.show(2).run()
+```
+
+We see here that the order of the fields doesn't matter as long as the
+names and the corresponding types agree. However, if we make a mistake in 
+any of the names and/or their types, then we get a compilation error. 
+
+Say we make a typo in a field name:
+
+```tut:silent
+case class PriceInfo2(ratio: Double, pricEE: Double)
+```
+
+```tut:book:fail
+aptWithRatio.project[PriceInfo2]
+```
+
+
+Say we make a mistake in the corresponding type:
+
+```tut:silent
+case class PriceInfo3(ratio: Int, price: Double) // ratio should be Double
+```
+
+```tut:book:fail
+aptWithRatio.project[PriceInfo3]
+```
+
+
+## User Defined Functions
+  
+
+Frameless supports lifting any Scala function (up to five arguments) to the 
+context of a particular `TypedDataset`:
+
+```tut:book
+// The function we want to use as UDF
+val priceModifier = 
+    (name: String, price:Double) => if(name == "Paris") price * 2.0 else price
+
+val udf = apartmentsTypedDS.makeUDF(priceModifier)
+
+val aptds = apartmentsTypedDS // For shorter expressions
+
+val adjustedPrice = aptds.select(aptds('city), udf(aptds('city), aptds('price)))
+
+adjustedPrice.show().run()
+``` 
+
+
+ 
+## GroupBy and Aggregations
+Let's suppose we wanted to retrieve the average apartment price in each city
+```tut:book
+val priceByCity = apartmentsTypedDS.groupBy(apartmentsTypedDS('city)).agg(avg(apartmentsTypedDS('price)))
 priceByCity.collect().run()
 ``` 
 Again if we try to aggregate a column that can't be aggregated, we get a compilation error
 ```tut:book:fail
-appartmentsTypedDS.groupBy(appartmentsTypedDS('city)).agg(avg(appartmentsTypedDS('city)))                                                         ^
+apartmentsTypedDS.groupBy(apartmentsTypedDS('city)).agg(avg(apartmentsTypedDS('city)))                                                         ^
 ```
+
+Finally, we conclude with an example combining `select` and `groupBy` 
+to calculate the average price/surface ratio per city:
+
+```tut:book
+val aptds = apartmentsTypedDS // For shorter expressions
+
+val cityPriceRatio =  aptds.select(aptds('city), aptds('price)/aptds('surface) )
+
+cityPriceRatio.groupBy(cityPriceRatio('_1)).agg(avg(cityPriceRatio('_2))).show().run()  
+``` 
+
+ 
+
 ```tut:invisible
 spark.stop()
 ``` 

--- a/docs/src/main/tut/TypedDataset.md
+++ b/docs/src/main/tut/TypedDataset.md
@@ -1,1 +1,147 @@
 # TypedDataset
+
+
+```tut:invisible
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+val conf = new SparkConf().setMaster("local[*]").setAppName("test").set("spark.ui.enabled", "false").set("spark.app.id", "tut-dataset")
+val spark = SparkSession.builder().config(conf).getOrCreate() 
+
+System.clearProperty("spark.master.port")
+System.clearProperty("spark.driver.port")
+System.clearProperty("spark.hostPort")
+System.setProperty("spark.cleaner.ttl", "300")
+
+// We are using this directory so let's make sure it is clean first 
+org.apache.commons.io.FileUtils.deleteDirectory(new java.io.File("/tmp/foo/"))
+```
+
+## Comparing Frameless TypedDatasets with standard Spark Datasets  
+
+
+
+**Goal:** 
+  This tutorial compares the standard Spark Datasets api with the one provided by
+  frameless' TypedDataset. It shows how TypedDatsets allows for an expressive and 
+  typesafe api with no compromises on performance. 
+ 
+ 
+For this tutorial we first create a simple dataset and save it on disk as a parquet file. 
+[Parquet](https://parquet.apache.org/) is a popular "big data" friendly columnar format and well supported by Spark. 
+It's important to know that when operating on parquet datasets, Spark knows that each column is stored 
+separately, so if we only need a subset of the columns Spark will optimize for this and avoid reading 
+the entire dataset.
+
+```tut:book
+import spark.implicits._
+
+// Our example case class Foo acting here as a schema
+case class Foo(i: Long, j: String)
+
+// Assuming spark is loaded and SparkSession is bind to spark
+val initialDs = spark.createDataset( Foo(1, "Q") :: Foo(10, "W") :: Foo(100, "E") :: Nil )
+
+// Assuming you are on Linux or Mac OS
+initialDs.write.parquet("/tmp/foo")
+
+val ds = spark.read.parquet("/tmp/foo").as[Foo]
+
+ds.show()
+```
+
+The value `ds` holds the content of the `initialDs` read from a parquet file. 
+Let's try to only use field `i` from Foo and see how Spark's Catalyst (the query optimizer) 
+optimizes this. 
+
+```tut:book
+// Using a standard Spark TypedColumn in select()
+val filteredDs = ds.filter($"i" === 10).select($"i".as[Long])
+
+filteredDs.show()
+```
+
+The `filteredDs` has fixed type of `Dataset[Long]`. This is of course correct
+but it does require some handholding by explicitly setting the `TypedColumn` in the `select` statement
+to return type `Long`. Let's take a quick look at the optimized Physical Plan. 
+
+```tut:book
+
+filteredDs.explain()
+
+```
+
+The last line is very important (see `ReadSchema`). The schema read 
+from the parquet file only required reading column `i` without needing to access column `j` 
+(or any other column for that matter). This is great! We have both an optimized query plan and typesafety! 
+
+Unfortunately, this syntax is not bulletproof. 
+Let's look at an example where this fails while reading a non existing column `x`. 
+The following statement works great at compile time and it will 
+fail at run time (apologies for the long stack trace):
+
+```tut:fail
+ds.filter($"i" === 10).select($"x".as[Long])
+```
+
+There are two things to improve. Fist, we would want to avoid the `at[Long]` casting that we are required
+to type for typesafely. This is clearly an area where we can introduce a bug but casting to an incompatible 
+type. Second, we want a solution where reference to a 
+non existing column name will fail at compilation time. 
+The standard Spark Dataset can achieve this using the following syntax.
+ 
+```tut:book
+ 
+ds.filter(_.i == 10).map(_.i).show()
+
+```
+
+This looks great! It reminds us the familiar syntax from Scala. 
+The two closures in filter and map are functions that operate on `Foo` and the 
+compiler will helps us capture all the mistakes we mentioned above.
+Unfortunately, this syntax does not allow Spark to optimize the code. 
+
+
+```tut:book
+
+ds.filter(_.i == 10).map(_.i).explain()
+
+```
+
+As we see from the explained Physical Plan, Spark was not able to optimize our query as before.
+ Reading the parquet file will required loading all the fields of `Foo`. This might be ok for
+ small datasets or for datasets with few columns, but will be extremely slow for most practical
+ applications. 
+ 
+ 
+The TypedDataset in frameless solves this problem. It allows for a simple and typesafe syntax 
+with a fully optimized query plan. 
+
+
+```tut:book
+import frameless.TypedDataset
+val fds = TypedDataset.create(ds)
+
+fds.filter( fds('i) === 10 ).select( fds('i) ).show().run()
+```
+
+And the optimized Physical Plan:
+
+
+```tut:book
+fds.filter( fds('i) === 10 ).select( fds('i) ).explain()
+```
+
+And the compiler is our friend.
+
+```tut:fail
+fds.filter( fds('i) === 10 ).select( fds('x) )
+```
+
+
+
+```tut:invisible
+org.apache.commons.io.FileUtils.deleteDirectory(new java.io.File("/tmp/foo/"))
+
+spark.stop()
+```

--- a/docs/src/main/tut/TypedDataset.md
+++ b/docs/src/main/tut/TypedDataset.md
@@ -23,7 +23,7 @@ org.apache.commons.io.FileUtils.deleteDirectory(new java.io.File("/tmp/foo/"))
 **Goal:** 
   This tutorial compares the standard Spark Datasets api with the one provided by
   frameless' TypedDataset. It shows how TypedDatsets allows for an expressive and 
-  typesafe api with no compromises on performance. 
+  type-safe api with no compromises on performance. 
  
  
 For this tutorial we first create a simple dataset and save it on disk as a parquet file. 
@@ -72,7 +72,7 @@ filteredDs.explain()
 
 The last line is very important (see `ReadSchema`). The schema read 
 from the parquet file only required reading column `i` without needing to access column `j`.
-This is great! We have both an optimized query plan and typesafety! 
+This is great! We have both an optimized query plan and type-safety! 
 
 
 Unfortunately, this syntax is not bulletproof: it fails at run-time if we try to access 
@@ -83,8 +83,8 @@ a non existing column `x`:
 ds.filter($"i" === 10).select($"x".as[Long])
 ```
 
-There are two things to improve here. Fist, we would want to avoid the `at[Long]` casting that we are required
-to type for typesafely. This is clearly an area where we can introduce a bug by casting to an incompatible 
+There are two things to improve here. First, we would want to avoid the `at[Long]` casting that we are required
+to type for type-safety. This is clearly an area where we can introduce a bug by casting to an incompatible 
 type. Second, we want a solution where reference to a 
 non existing column name fails at compilation time. 
 The standard Spark Dataset can achieve this using the following syntax.
@@ -117,7 +117,7 @@ closures. It only knows that they both take one argument of type `Foo`, but it h
 we use just one or all of `Foo`'s fields. 
  
  
-The TypedDataset in frameless solves this problem. It allows for a simple and typesafe syntax 
+The TypedDataset in frameless solves this problem. It allows for a simple and type-safe syntax 
 with a fully optimized query plan. 
 
 


### PR DESCRIPTION
This aims to be a short tutorial that explains what you can do with standard Datasets and how TypedDatsets provide a much more typesafe syntax without compromising on performance (Catalyst can work great with the syntax we provide). 

Please feel free to comment! This is a first pass, so I am open to suggestions. Also, this is by no means complete. It aims to be be complemented with more details and explanation of the apis provided later. 