### PR TITLE
Support for safe projections between compatible types.

### DIFF
--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -30,6 +30,23 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     TypedDataset.create(dataset.as[U](TypedExpressionEncoder[U]))
   }
 
+  /** Returns a new [[TypedDataset]] where each record has been mapped on to the specified type.
+    * Unlike `as` the projection U may include a subset of the columns of T and the column names and types must agree.
+    *
+    * {{{
+    *   case class Foo(i: Int, j: String)
+    *   case class Bar(j: String)
+    *
+    *   val t: TypedDataset[Foo] = ...
+    *   val b: TypedDataset[Bar] = t.project[Bar]
+    *
+    *   case class BarErr(e: String)
+    *   // The following does not compile because `Foo` doesn't have a field with name `e`
+    *   val e: TypedDataset[BarErr] = t.project[BarErr]
+    * }}}
+    */
+  def project[U](implicit projector: SmartProject[T,U]): TypedDataset[U] = projector.apply(this)
+
   /** Returns the number of elements in the [[TypedDataset]].
     *
     * Differs from `Dataset#count` by wrapping it's result into a [[Job]].

--- a/dataset/src/main/scala/frameless/ops/SmartProject.scala
+++ b/dataset/src/main/scala/frameless/ops/SmartProject.scala
@@ -1,0 +1,56 @@
+package frameless
+package ops
+
+import shapeless.ops.hlist.ToTraversable
+import shapeless.ops.record.{Keys, SelectAll, Values}
+import shapeless.{HList, LabelledGeneric}
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(msg = "Cannot prove that ${T} can be projected to ${U}. Perhaps not all member names and types of ${U} are the same in ${T}?")
+case class SmartProject[T: TypedEncoder, U: TypedEncoder](apply: TypedDataset[T] => TypedDataset[U])
+
+object SmartProject {
+  /**
+    * Proofs that there is a type-safe projection from a type T to another type U. It requires that:
+    * (a) both T and U are Products for which a LabelledGeneric can be derived (e.g., case classes),
+    * (b) all members of U have a corresponding member in T that has both the same name and type.
+    *
+    * @param tgen the LabelledGeneric derived for T
+    * @param ugen the LabelledGeneric derived for U
+    * @param keys the keys of U
+    * @param select selects all the keys of U from T
+    * @param values selects all the values of LabeledGeneric[U]
+    * @param typeEqualityProof proof that U and the projection of T have the same type
+    * @param keysTraverse allows for traversing the keys of U
+    * @tparam T the original type T
+    * @tparam U the projected type U
+    * @tparam TRec shapeless' Record representation of T
+    * @tparam TProj the projection of T using the keys of U
+    * @tparam URec shapeless' Record representation of U
+    * @tparam UVals the values of U as an HList
+    * @tparam UKeys the keys of U as an HList
+    * @return a projection if it exists
+    */
+  implicit def deriveProduct[
+  T: TypedEncoder,
+  U: TypedEncoder,
+  TRec <: HList,
+  TProj <: HList,
+  URec <: HList,
+  UVals <: HList,
+  UKeys <: HList](
+    implicit
+    tgen: LabelledGeneric.Aux[T, TRec],
+    ugen: LabelledGeneric.Aux[U, URec],
+    keys: Keys.Aux[URec, UKeys],
+    select: SelectAll.Aux[TRec, UKeys, TProj],
+    values: Values.Aux[URec, UVals],
+    typeEqualityProof: UVals =:= TProj,
+    keysTraverse: ToTraversable.Aux[UKeys, Seq, Symbol]
+  ): SmartProject[T,U] = SmartProject[T, U]( from => {
+        val names = keys.apply.to[Seq].map(_.name).map(from.dataset.col)
+        TypedDataset.create(from.dataset.toDF().select(names: _*).as[U](TypedExpressionEncoder[U]))
+      }
+    )
+}

--- a/dataset/src/test/scala/frameless/ops/SmartProjectTest.scala
+++ b/dataset/src/test/scala/frameless/ops/SmartProjectTest.scala
@@ -1,0 +1,42 @@
+package frameless
+package ops
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+import shapeless.test.illTyped
+
+
+case class Foo(i: Int, j: Int, x: String)
+case class Bar(i: Int, x: String)
+case class InvalidFooProjectionType(i: Int, x: Boolean)
+case class InvalidFooProjectionName(i: Int, xerr: String)
+
+class SmartProjectTest extends TypedDatasetSuite {
+  val dataset = TypedDataset.create(Foo(1, 2, "hi") :: Foo(2, 3, "there") :: Nil)
+
+  test("project Foo to Bar") {
+    assert(dataset.project[Bar].count().run() === 2)
+  }
+
+  test("project to InvalidFooProjection should not type check") {
+    illTyped("dataset.project[InvalidFooProjectionType]")
+    illTyped("dataset.project[InvalidFooProjectionName]")
+  }
+
+  test("X4 to X1,X2,X3,X4 projections") {
+    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder](data: Vector[X4[A, B, C, D]]): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.project[X4[A, B, C, D]].collect().run().toVector ?= data
+      dataset.project[X3[A, B, C]].collect().run().toVector ?= data.map(x => X3(x.a, x.b, x.c))
+      dataset.project[X2[A, B]].collect().run().toVector ?= data.map(x => X2(x.a, x.b))
+      dataset.project[X1[A]].collect().run().toVector ?= data.map(x => X1(x.a))
+    }
+
+    check(forAll(prop[Int, String, X1[String], Boolean] _))
+    check(forAll(prop[Short, Long, String, Boolean] _))
+    check(forAll(prop[Short, (Boolean, Boolean), String, (Int, Int)] _))
+    check(forAll(prop[X2[String, Boolean], (Boolean, Boolean), String, Boolean] _))
+    check(forAll(prop[X2[String, Boolean], X3[Boolean, Boolean, Long], String, String] _))
+  }
+}


### PR DESCRIPTION
This edit allows for safe projections between compatible case classes. Many times (it happens a lot with Parquet and columnar schemas) we have really high dimensional data we persist (usually for schema denormalization). This method will allow us to easily select a subset of the columns by using a simple projection to a new case class that has the same name/types for the fields that we are interested in. Here is an example:

```scala
 case class Foo(i: Int, j: String)
 case class Bar(j: String)
 
val t: TypedDataset[Foo] = ...
val b: TypedDataset[Bar] = t.project[Bar]

case class BarErr(e: String)
// The following does not compile because `Foo` doesn't have a field with name `e`
val e: TypedDataset[BarErr] = t.project[BarErr]
```