### PR TITLE
Fix udfs

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -11,6 +11,7 @@ import scala.annotation.implicitNotFound
 
 sealed trait UntypedExpression[T] {
   def expr: Expression
+  def uencoder: TypedEncoder[_]
 }
 
 /** Expression used in `select`-like constructions.

--- a/dataset/src/main/scala/frameless/functions/Udf.scala
+++ b/dataset/src/main/scala/frameless/functions/Udf.scala
@@ -1,7 +1,12 @@
 package frameless
 package functions
 
-import org.apache.spark.sql.catalyst.expressions.ScalaUDF
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Expression, NonSQLExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.objects.LambdaVariable
+import org.apache.spark.sql.types.DataType
+import shapeless.syntax.std.tuple._
 
 /** Documentation marked "apache/spark" is thanks to apache/spark Contributors
   * at https://github.com/apache/spark, licensed under Apache v2.0 available at
@@ -17,10 +22,7 @@ trait Udf {
   def udf[T, A, R: TypedEncoder](f: A => R):
     TypedColumn[T, A] => TypedColumn[T, R] = {
     u =>
-      val aenc = u.uencoder
-
-      val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u.expr),
-        Seq(aenc.targetDataType))
+      val scalaUdf = FramelessUdf(f, List(u), TypedEncoder[R])
       new TypedColumn[T, R](scalaUdf)
   }
 
@@ -31,11 +33,8 @@ trait Udf {
     */
   def udf[T, A1, A2, R: TypedEncoder](f: (A1,A2) => R):
     (TypedColumn[T, A1], TypedColumn[T, A2]) => TypedColumn[T, R] = {
-    (u1, u2) =>
-      val (a1enc, a2enc) = (u1.uencoder, u2.uencoder)
-
-      val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr),
-        Seq(a1enc.targetDataType, a2enc.targetDataType))
+    case us =>
+      val scalaUdf = FramelessUdf(f, us.toList[UntypedExpression[T]], TypedEncoder[R])
       new TypedColumn[T, R](scalaUdf)
     }
 
@@ -46,11 +45,8 @@ trait Udf {
     */
   def udf[T, A1, A2, A3, R: TypedEncoder](f: (A1,A2,A3) => R):
   (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3]) => TypedColumn[T, R] = {
-    (u1, u2, u3) =>
-      val (a1enc, a2enc, a3enc) = (u1.uencoder, u2.uencoder, u3.uencoder)
-
-      val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr, u3.expr),
-        Seq(a1enc.targetDataType, a2enc.targetDataType, a3enc.targetDataType))
+    case us =>
+      val scalaUdf = FramelessUdf(f, us.toList[UntypedExpression[T]], TypedEncoder[R])
       new TypedColumn[T, R](scalaUdf)
     }
 
@@ -61,11 +57,8 @@ trait Udf {
     */
   def udf[T, A1, A2, A3, A4, R: TypedEncoder](f: (A1,A2,A3,A4) => R):
     (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3], TypedColumn[T, A4]) => TypedColumn[T, R] = {
-    (u1, u2, u3, u4) =>
-      val (a1enc, a2enc, a3enc, a4enc) = (u1.uencoder, u2.uencoder, u3.uencoder, u4.uencoder)
-
-      val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr, u3.expr, u4.expr),
-        Seq(a1enc.targetDataType, a2enc.targetDataType, a3enc.targetDataType, a4enc.targetDataType))
+    case us =>
+      val scalaUdf = FramelessUdf(f, us.toList[UntypedExpression[T]], TypedEncoder[R])
       new TypedColumn[T, R](scalaUdf)
     }
 
@@ -75,13 +68,119 @@ trait Udf {
     * apache/spark
     */
   def udf[T, A1, A2, A3, A4, A5, R: TypedEncoder](f: (A1,A2,A3,A4,A5) => R):
-    (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3], TypedColumn[T, A4],  TypedColumn[T, A5]) => TypedColumn[T, R] = {
-    (u1, u2, u3, u4, u5) =>
-      val (a1enc, a2enc, a3enc, a4enc, a5enc) = (u1.uencoder, u2.uencoder, u3.uencoder, u4.uencoder, u5.uencoder)
-
-      val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr, u3.expr, u4.expr, u5.expr),
-        Seq(a1enc.targetDataType, a2enc.targetDataType, a3enc.targetDataType, a4enc.targetDataType, a5enc.targetDataType))
+    (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3], TypedColumn[T, A4], TypedColumn[T, A5]) => TypedColumn[T, R] = {
+    case us =>
+      val scalaUdf = FramelessUdf(f, us.toList[UntypedExpression[T]], TypedEncoder[R])
       new TypedColumn[T, R](scalaUdf)
     }
 }
 
+/**
+  * NB: Implementation detail, isn't intended to be directly used.
+  *
+  * Our own implementation of `ScalaUDF` from Catalyst compatible with [[TypedEncoder]].
+  */
+case class FramelessUdf[T, R](
+  function: AnyRef,
+  encoders: Seq[TypedEncoder[_]],
+  children: Seq[Expression],
+  rencoder: TypedEncoder[R]
+) extends Expression with NonSQLExpression {
+
+  override def nullable: Boolean = rencoder.nullable
+  override def toString: String = s"FramelessUdf(${children.mkString(", ")})"
+
+  def eval(input: InternalRow): Any = {
+    val ctx = new CodegenContext()
+    val eval = genCode(ctx)
+
+    val codeBody = s"""
+      public scala.Function1<InternalRow, Object> generate(Object[] references) {
+        return new FramelessUdfEvalImpl(references);
+      }
+
+      class FramelessUdfEvalImpl extends scala.runtime.AbstractFunction1<InternalRow, Object> {
+        private final Object[] references;
+        ${ctx.declareMutableStates()}
+        ${ctx.declareAddedFunctions()}
+
+        public FramelessUdfEvalImpl(Object[] references) {
+          this.references = references;
+          ${ctx.initMutableStates()}
+        }
+
+        public java.lang.Object apply(java.lang.Object z) {
+          InternalRow ${ctx.INPUT_ROW} = (InternalRow) z;
+          ${eval.code}
+          return ${eval.isNull} ? ((Object)null) : ((Object)${eval.value});
+        }
+      }
+    """
+
+    val code = CodeFormatter.stripOverlappingComments(
+      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+
+    val codegen = CodeGenerator.compile(code).generate(ctx.references.toArray).asInstanceOf[InternalRow => AnyRef]
+
+    codegen(input)
+  }
+
+  def dataType: DataType = rencoder.targetDataType
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    ctx.references += this
+
+    val internalTerm = ctx.freshName("internal")
+    val internalNullTerm = ctx.freshName("internalNull")
+    val internalTpe = ctx.boxedType(rencoder.sourceDataType)
+    val internalExpr = LambdaVariable(internalTerm, internalNullTerm, rencoder.targetDataType)
+
+    // save reference to `function` field from `FramelessUdf` to call it later
+    val framelessUdfClassName = classOf[FramelessUdf[_, _]].getName
+    val funcClassName = s"scala.Function${children.size}"
+    val funcTerm = ctx.freshName("udf")
+    val funcExpressionIdx = ctx.references.size - 1
+    ctx.addMutableState(funcClassName, funcTerm,
+      s"this.$funcTerm = ($funcClassName)((($framelessUdfClassName)references" +
+        s"[$funcExpressionIdx]).function());")
+
+    val (argsCode, funcArguments) = encoders.zip(children).map {
+      case (encoder, child) =>
+        val eval = child.genCode(ctx)
+        val codeTpe = ctx.boxedType(encoder.sourceDataType)
+        val argTerm = ctx.freshName("arg")
+        val convert = s"${eval.code}\n$codeTpe $argTerm = ${eval.isNull} ? (($codeTpe)null) : (($codeTpe)(${eval.value}));"
+
+        (convert, argTerm)
+    }.unzip
+
+    val resultEval = rencoder.extractorFor(internalExpr).genCode(ctx)
+
+    ev.copy(code = s"""
+      ${argsCode.mkString("\n")}
+
+      $internalTpe $internalTerm =
+        ($internalTpe)$funcTerm.apply(${funcArguments.mkString(", ")});
+      boolean $internalNullTerm = $internalTerm == null;
+
+      ${resultEval.code}
+      """,
+      value = resultEval.value,
+      isNull = resultEval.isNull
+    )
+  }
+}
+
+object FramelessUdf {
+  // Spark needs case class with `children` field to mutate it
+  def apply[T, R](
+    function: AnyRef,
+    cols: Seq[UntypedExpression[T]],
+    rencoder: TypedEncoder[R]
+  ): FramelessUdf[T, R] = FramelessUdf(
+    function = function,
+    encoders = cols.map(_.uencoder).toList,
+    children = cols.map(x => x.uencoder.constructorFor(x.expr)).toList,
+    rencoder = rencoder
+  )
+}

--- a/dataset/src/test/scala/frameless/CollectTests.scala
+++ b/dataset/src/test/scala/frameless/CollectTests.scala
@@ -45,6 +45,9 @@ class CollectTests extends TypedDatasetSuite {
     check(forAll(prop[X1[Vector[Food]]] _))
     check(forAll(prop[X1[Vector[X1[Food]]]] _))
     check(forAll(prop[X1[Vector[X1[Int]]]] _))
+
+    // TODO this doesn't work, and never worked...
+    // check(forAll(prop[X1[Option[X1[Option[Int]]]]] _))
   }
 }
 

--- a/dataset/src/test/scala/frameless/forward/FlatMapTests.scala
+++ b/dataset/src/test/scala/frameless/forward/FlatMapTests.scala
@@ -1,14 +1,9 @@
 package frameless
 
 import org.scalacheck.Prop._
-import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.scalacheck.Prop
 
 class FlatMapTests extends TypedDatasetSuite {
-
-  // see issue with scalacheck non serializable Vector: https://github.com/rickynils/scalacheck/issues/315
-  implicit def arbVector[A](implicit A: Arbitrary[A]): Arbitrary[Vector[A]] =
-   Arbitrary(Gen.listOf(A.arbitrary).map(_.toVector))
-
   test("flatMap") {
     def prop[A: TypedEncoder, B: TypedEncoder](flatMapFunction: A => Vector[B], data: Vector[A]): Prop =
       TypedDataset.create(data).flatMap(flatMapFunction).collect().run().toVector =? data.flatMap(flatMapFunction)

--- a/dataset/src/test/scala/frameless/package.scala
+++ b/dataset/src/test/scala/frameless/package.scala
@@ -25,4 +25,9 @@ package object frameless {
   implicit def arbTuple1[A: Arbitrary] = Arbitrary {
     Arbitrary.arbitrary[A].map(Tuple1(_))
   }
+
+  // see issue with scalacheck non serializable Vector: https://github.com/rickynils/scalacheck/issues/315
+  implicit def arbVector[A](implicit A: Arbitrary[A]): Arbitrary[Vector[A]] =
+    Arbitrary(Gen.listOf(A.arbitrary).map(_.toVector))
+
 }


### PR DESCRIPTION
We didn't use our encoders before, instead we used `ScalaUDF` that uses
default ones that aren't compatible with `TypedEncoder`. We introduce
`FramelessUdf` that uses `TypedEncoder` to support udfs. There are
2 special cases to mention:

1. udf is called within codegen
2. udf is directly evaluated within local projection

`TypedEncoder` doesn't support runtime evaluation, only codegen, that's
why we handle (2) by generating code from (1), compiling and executing
it.