### PR TITLE
Compatibility with Spark 2.1.0

### DIFF
--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -271,7 +271,7 @@ object TypedEncoder {
           underlying.targetDataType
         ),
         "array",
-        ScalaReflection.dataTypeFor[Array[Any]]
+        ScalaReflection.dataTypeFor[Array[AnyRef]]
       )
 
       StaticInvoke(


### PR DESCRIPTION
Previously tests were failing with Spark 2.1.0. This pull request introduces source/test compatibility with both Spark 2.1.0 and 2.0.2. 